### PR TITLE
Features - OntoUML Parser and Syntax (with Endurants)

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -15,3 +15,32 @@ interface IModel {
   authors?: string[];
   structuralElements?: IStructuralElement[];
 }
+
+interface IStereotype {
+  name: string;
+  uri: string;
+  specializes: string[];
+  rigidity: string;
+  sortality: string;
+  ultimateSortal: boolean;
+}
+
+interface ISelfLink {
+  self: string;
+}
+
+interface IRelatedLink {
+  related: {
+    hred: string;
+    meta: object;
+  };
+}
+
+interface IOntoUMLError {
+  id?: string;
+  code: string;
+  title: string;
+  detail: string;
+  links: ISelfLink | IRelatedLink;
+  meta?: object;
+}

--- a/__tests__/libs/ontouml_model/ontouml_model.spec.ts
+++ b/__tests__/libs/ontouml_model/ontouml_model.spec.ts
@@ -1,9 +1,9 @@
-import { modelExample1 } from 'ontouml-example-models';
+import { modelInvalidExample1 } from 'ontouml-example-models';
 import OntoUMLModel from '@libs/ontouml_model';
 
 describe('OntoUML Model', () => {
   it('Should validate the model', async () => {
-    const model = new OntoUMLModel(modelExample1);
+    const model = new OntoUMLModel(modelInvalidExample1);
 
     expect(model.isValid()).toBe(true);
   });

--- a/__tests__/libs/ontouml_model/ontouml_model.spec.ts
+++ b/__tests__/libs/ontouml_model/ontouml_model.spec.ts
@@ -1,4 +1,6 @@
-import { modelInvalidExample1 } from 'ontouml-example-models';
+// import { modelInvalidExample1 } from 'ontouml-example-models';
+// TODO Replace local dependencies on example models for dependencies to 'ontouml-example-models' project
+import { modelInvalidExample1 } from '@test-models/invalids';
 import OntoUMLModel from '@libs/ontouml_model';
 
 describe('OntoUML Model', () => {

--- a/__tests__/libs/ontouml_model/services/ontouml_parser/ontouml_parser.spec.ts
+++ b/__tests__/libs/ontouml_model/services/ontouml_parser/ontouml_parser.spec.ts
@@ -1,4 +1,4 @@
-import { modelExample1 } from 'ontouml-example-models';
+import { modelInvalidExample1 } from '@test-models/invalids';
 import OntoUMLParser from '@libs/ontouml_model/services/ontouml_parser';
 import { CLASS_TYPE } from '@constants/model_types';
 
@@ -11,13 +11,13 @@ describe('OntoUML Parser', () => {
           uri: 'invalid.model',
         });
       } catch (error) {
-        expect(error.message).toBe('data.uri should match format "uri"');
+        expect(error.detail).toBe('data.uri should match format "uri"');
       }
     });
   });
 
   describe('OntoUML Example Model 1', () => {
-    const parser = new OntoUMLParser(modelExample1);
+    const parser = new OntoUMLParser(modelInvalidExample1);
 
     it('Should return a valid model', async () => {
       expect(parser.isValid()).toBe(true);

--- a/__tests__/libs/ontouml_model/services/ontouml_syntax/onotuml_syntax.spec.ts
+++ b/__tests__/libs/ontouml_model/services/ontouml_syntax/onotuml_syntax.spec.ts
@@ -1,0 +1,58 @@
+import {
+  modelInvalidExample1,
+  modelInvalidExample4,
+  modelInvalidExample5,
+  modelInvalidExample6,
+} from '@test-models/invalids';
+import OntoUMLParser from '@libs/ontouml_model/services/ontouml_parser';
+import OntoUMLSyntax from '@libs/ontouml_model/services/ontouml_syntax';
+
+describe('OntoUML Syntax', () => {
+  describe('OntoUML Example Model 1', () => {
+    it('Should return 3 errors of missing stereotype', async () => {
+      const parser = new OntoUMLParser(modelInvalidExample1);
+      const syntax = new OntoUMLSyntax(parser);
+
+      const errors = await syntax.verifyEndurantTypes();
+
+      expect(errors[0].code).toBe('ontouml_stereotype_error');
+      expect(errors.length).toBe(3);
+    });
+  });
+
+  describe('OntoUML Example Model 4', () => {
+    it('Should return an error of ultimate sortal specialization', async () => {
+      const parser = new OntoUMLParser(modelInvalidExample4);
+      const syntax = new OntoUMLSyntax(parser);
+
+      const errors = await syntax.verifyEndurantTypes();
+
+      expect(errors[0].code).toBe('ontouml_specialization_error');
+      expect(errors.length).toBe(1);
+    });
+  });
+
+  describe('OntoUML Example Model 5', () => {
+    it("Should return an error of kind's specialization", async () => {
+      const parser = new OntoUMLParser(modelInvalidExample5);
+      const syntax = new OntoUMLSyntax(parser);
+
+      const errors = await syntax.verifyEndurantTypes();
+
+      expect(errors[0].code).toBe('ontouml_specialization_error');
+      expect(errors.length).toBe(1);
+    });
+  });
+
+  describe('OntoUML Example Model 6', () => {
+    it('Should return an error of non-sortal specialization', async () => {
+      const parser = new OntoUMLParser(modelInvalidExample6);
+      const syntax = new OntoUMLSyntax(parser);
+
+      const errors = await syntax.verifyEndurantTypes();
+
+      expect(errors[0].code).toBe('ontouml_specialization_error');
+      expect(errors.length).toBe(1);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,11 @@ module.exports = {
     "node",
   ],
   moduleNameMapper: {
+    "^@test-models(.*)": "<rootDir>/test_models$1",
     "^@constants(.*)": "<rootDir>/src/constants$1",
+    "^@error(.*)": "<rootDir>/src/error$1",
     "^@libs(.*)": "<rootDir>/src/libs$1",
+    "^@rules(.*)": "<rootDir>/src/rules$1",
     "^@schemas(.*)": "<rootDir>/schemas$1",
     "^@utils(.*)": "<rootDir>/src/utils$1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5775,7 +5775,7 @@
       }
     },
     "ontouml-example-models": {
-      "version": "git+https://github.com/OntoUML/ontouml-example-models.git#8fb8bce18cd2902bbb0cbeefccd80808af4b6f00",
+      "version": "git+https://github.com/OntoUML/ontouml-example-models.git#903f686ac0c3c141faa8ec4bc15bed0147683ddb",
       "from": "git+https://github.com/OntoUML/ontouml-example-models.git",
       "dev": true
     },
@@ -7342,6 +7342,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniqid": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
+      "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg=="
     },
     "unique-string": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "pre-push": "npm run lint && npm test"
   },
   "_moduleAliases": {
+    "@test-models": "test_models",
     "@constants": "src/constants",
+    "@error": "src/error",
     "@libs": "src/libs",
+    "@rules": "src/rules",
     "@schemas": "schemas",
     "@utils": "src/utils"
   },
@@ -33,7 +36,8 @@
     "memoizee": "^0.4.14",
     "nodemon": "^1.19.4",
     "regenerator-runtime": "^0.13.3",
-    "tslib": "~1.10.0"
+    "tslib": "~1.10.0",
+    "uniqid": "^5.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
@@ -51,7 +55,7 @@
     "module-alias": "^2.2.2",
     "npm-run-all": "^4.1.5",
     "onchange": "^6.1.0",
-    "ontouml-example-models": "https://github.com/OntoUML/ontouml-example-models",
+    "ontouml-example-models": "git+https://github.com/OntoUML/ontouml-example-models.git",
     "prettier": "~1.18.2",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.0.0",

--- a/src/constants/stereotypes_constraints.ts
+++ b/src/constants/stereotypes_constraints.ts
@@ -1,0 +1,7 @@
+// Rigidity
+export const RIGID: 'RIGID' = 'RIGID';
+export const ANTI_RIGID: 'ANTI_RIGID' = 'ANTI_RIGID';
+export const SEMI_RIGID: 'SEMI_RIGID' = 'SEMI_RIGID';
+// Sortality
+export const SORTAL: 'SORTAL' = 'SORTAL';
+export const NON_SORTAL: 'NON_SORTAL' = 'NON_SORTAL';

--- a/src/error/ontouml_error.ts
+++ b/src/error/ontouml_error.ts
@@ -1,0 +1,36 @@
+import uniqid from 'uniqid';
+
+class OntoUMLError {
+  id: IOntoUMLError['id'];
+  code: IOntoUMLError['code'];
+  title: IOntoUMLError['title'];
+  detail: IOntoUMLError['detail'];
+  links: IOntoUMLError['links'];
+  meta?: IOntoUMLError['meta'];
+
+  constructor(raw: IOntoUMLError) {
+    const { id, code, title, detail, links, meta } = raw;
+
+    this.id = id || uniqid();
+    this.code = code;
+    this.title = title;
+    this.detail = detail;
+    this.links = links;
+    this.meta = meta;
+  }
+
+  print() {
+    const { id, code, title, detail, links, meta } = this;
+
+    console.log({
+      id,
+      code,
+      title,
+      detail,
+      links,
+      meta,
+    });
+  }
+}
+
+export default OntoUMLError;

--- a/src/error/ontouml_parser/index.ts
+++ b/src/error/ontouml_parser/index.ts
@@ -1,0 +1,3 @@
+import OntoUMLParserError from './ontouml_parser_error';
+
+export { OntoUMLParserError };

--- a/src/error/ontouml_parser/ontouml_parser_error.ts
+++ b/src/error/ontouml_parser/ontouml_parser_error.ts
@@ -1,0 +1,17 @@
+import OntoUMLError from '@error/ontouml_error';
+
+class OntoUMLParserError extends OntoUMLError {
+  constructor(model: IModel, detail: string) {
+    super({
+      title: 'OntoUML Parser Error',
+      code: 'ontouml_parser_error',
+      detail,
+      links: {
+        self: 'https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Parser',
+      },
+      meta: { model },
+    });
+  }
+}
+
+export default OntoUMLParserError;

--- a/src/error/ontouml_syntax/index.ts
+++ b/src/error/ontouml_syntax/index.ts
@@ -1,0 +1,4 @@
+import OntoUMLStereotypeError from './onotuml_stereotype_error';
+import OntoUMLSpecializationError from './ontouml_specialization_error';
+
+export { OntoUMLStereotypeError, OntoUMLSpecializationError };

--- a/src/error/ontouml_syntax/onotuml_stereotype_error.ts
+++ b/src/error/ontouml_syntax/onotuml_stereotype_error.ts
@@ -1,0 +1,30 @@
+import OntoUMLError from '@error/ontouml_error';
+
+class OntoUMLStereotypeError extends OntoUMLError {
+  constructor(structuralElement: IStructuralElement) {
+    const { stereotypes, name, uri } = structuralElement;
+    const elementName = name || uri;
+    let detail = '';
+
+    if (!stereotypes || stereotypes.length === 0) {
+      detail = `${structuralElement['@type']} "${elementName}" must contain 1 stereotype.`;
+    } else if (stereotypes.length === 1) {
+      detail = `The stereotype ${stereotypes[0]} of ${structuralElement['@type']} "${elementName}" is not a valid OntoUML stereotype.`;
+    } else {
+      detail = `${structuralElement['@type']} "${elementName}" must contain only 1 stereotype.`;
+    }
+
+    super({
+      title: 'OntoUML Stereotype Error',
+      code: 'ontouml_stereotype_error',
+      detail,
+      links: {
+        self:
+          'https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Syntax-Constraints',
+      },
+      meta: { structuralElement },
+    });
+  }
+}
+
+export default OntoUMLStereotypeError;

--- a/src/error/ontouml_syntax/ontouml_specialization_error.ts
+++ b/src/error/ontouml_syntax/ontouml_specialization_error.ts
@@ -1,0 +1,18 @@
+import OntoUMLError from '@error/ontouml_error';
+
+class OntoUMLSpecializationError extends OntoUMLError {
+  constructor(detail: string, meta?: object) {
+    super({
+      title: 'OntoUML Specialization Error',
+      code: 'ontouml_specialization_error',
+      detail,
+      links: {
+        self:
+          'https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Specialization-Table',
+      },
+      meta,
+    });
+  }
+}
+
+export default OntoUMLSpecializationError;

--- a/src/libs/ontouml_model/services/ontouml_parser/index.ts
+++ b/src/libs/ontouml_model/services/ontouml_parser/index.ts
@@ -1,5 +1,6 @@
 import Ajv from 'ajv';
 import schema from '@schemas/ontouml.schema.json';
+import { OntoUMLParserError } from '@error/ontouml_parser';
 import OntoUMLParserClass from './ontouml_parser_class';
 import OntoUMLParserGeneralizationLink from './ontouml_parser_generalization_link';
 
@@ -28,7 +29,7 @@ class OntoUMLParser {
     const isModelValid = ajv.validate('OntoUMLModel', model);
 
     if (!isModelValid) {
-      throw new Error(ajv.errorsText());
+      throw new OntoUMLParserError(model, ajv.errorsText());
     }
 
     this._valid = isModelValid ? true : false;

--- a/src/libs/ontouml_model/services/ontouml_syntax/index.ts
+++ b/src/libs/ontouml_model/services/ontouml_syntax/index.ts
@@ -1,14 +1,33 @@
 import OntoUMLParser from '../ontouml_parser';
+import OntoUMLSyntaxEndurants from './ontouml_syntax_endurants';
 
 class OntoUMLSyntax {
-  private _parser: OntoUMLParser;
+  verifyEndurantTypes: () => Promise<IOntoUMLError[]>;
 
   constructor(parser: OntoUMLParser) {
-    this._parser = parser;
-  }
+    const syntaxEndurants = new OntoUMLSyntaxEndurants(parser);
 
-  get parser() {
-    return this._parser;
+    const serviceMethods = [
+      {
+        service: syntaxEndurants,
+        serviceClass: OntoUMLSyntaxEndurants,
+        ignoreMethods: [],
+      },
+    ];
+
+    for (const { service, serviceClass, ignoreMethods } of serviceMethods) {
+      const methods = [
+        ...Object.getOwnPropertyNames(service),
+        ...Object.getOwnPropertyNames(serviceClass.prototype),
+      ];
+      const ignore = ['constructor', ...ignoreMethods];
+
+      for (const method of methods) {
+        if (!ignore.includes(method) && typeof service[method] === 'function') {
+          this[method] = service[method].bind(service);
+        }
+      }
+    }
   }
 }
 

--- a/src/libs/ontouml_model/services/ontouml_syntax/ontouml_syntax_endurants.ts
+++ b/src/libs/ontouml_model/services/ontouml_syntax/ontouml_syntax_endurants.ts
@@ -1,0 +1,239 @@
+import {
+  OntoUMLStereotypeError,
+  OntoUMLSpecializationError,
+} from '@error/ontouml_syntax';
+import { SORTAL, NON_SORTAL } from '@constants/stereotypes_constraints';
+import OntoUMLRules from '@rules/ontouml_rules';
+import OntoUMLParser from '../ontouml_parser';
+
+class OntoUMLSyntaxEndurants {
+  private _rules: OntoUMLRules;
+  private _parser: OntoUMLParser;
+  private _errors: IOntoUMLError[];
+
+  constructor(parser: OntoUMLParser) {
+    this._rules = new OntoUMLRules('1.0');
+    this._parser = parser;
+    this._errors = [];
+  }
+
+  async verifyEndurantTypes(): Promise<IOntoUMLError[]> {
+    const classes = this._parser.getClasses();
+
+    await Promise.all([
+      this.verifyStereotypes(classes),
+      this.verifyClasses(classes),
+    ]);
+
+    return this._errors;
+  }
+
+  async verifyStereotypes(structuralElements: IStructuralElement[]) {
+    const stereotypes = this._rules.getStereotypesURI();
+
+    const invalidElements = structuralElements.filter(
+      (structuralElement: IStructuralElement) =>
+        !structuralElement.stereotypes ||
+        !stereotypes.includes(structuralElement.stereotypes[0]) ||
+        structuralElement.stereotypes.length !== 1,
+    );
+    const hasInvalidElements = invalidElements.length > 0;
+
+    if (hasInvalidElements) {
+      for (let i = 0; i < invalidElements.length; i += 1) {
+        this._errors.push(new OntoUMLStereotypeError(invalidElements[i]));
+      }
+    }
+
+    return true;
+  }
+
+  async verifyClasses(classes: IStructuralElement[]) {
+    const sortalStereotypesURI = this._rules.getStereotypesURI({
+      sortality: SORTAL,
+      ultimateSortal: false,
+    });
+
+    const nonSortalStereotypesURI = this._rules.getStereotypesURI({
+      sortality: NON_SORTAL,
+    });
+
+    try {
+      for (let i = 0; i < classes.length; i += 1) {
+        const classElement = classes[i];
+        const stereotype = classElement.stereotypes[0];
+
+        await this.verifySpecializations(classElement);
+
+        if (nonSortalStereotypesURI.includes(stereotype)) {
+          await this.verifyNonSortalSpecializations(classElement);
+        }
+
+        if (sortalStereotypesURI.includes(stereotype)) {
+          await this.verifySortalitySpecializations(classElement);
+        }
+      }
+    } catch (error) {
+      // ignore
+    }
+
+    return true;
+  }
+
+  async verifySpecializations(classElement: IStructuralElement) {
+    const { stereotypes, uri } = classElement;
+    const parents = this._parser.getClassParents(uri);
+    const stereotype = stereotypes[0];
+
+    for (let i = 0; i < parents.length; i += 1) {
+      const parentElement = parents[i];
+      const parentStereotype = parentElement.stereotypes[0];
+      const hasValidSpecialization = this._rules.isValidSpecialization(
+        stereotype,
+        parentStereotype,
+      );
+
+      if (!hasValidSpecialization) {
+        const elementName = classElement.name || classElement.uri;
+        const parentName = parentElement.name || parentElement.uri;
+        const elementStereotypeName = this._rules.getStereotypeNameByURI(
+          classElement.stereotypes[0],
+        );
+        const parentStereotypeName = this._rules.getStereotypeNameByURI(
+          parentElement.stereotypes[0],
+        );
+
+        const errorDetail = `Class "${elementName}" of stereotype ${elementStereotypeName} can not specialize "${parentName}" of stereotype ${parentStereotypeName}.`;
+
+        this._errors.push(
+          new OntoUMLSpecializationError(errorDetail, {
+            structuralElement: classElement,
+            parentElement,
+          }),
+        );
+      }
+    }
+
+    return true;
+  }
+
+  // Given a non-sortal N, there must be a sortal S that specializes N, or specializes a non-sortal supertype common to both N and S.
+  async verifyNonSortalSpecializations(classElement: IStructuralElement) {
+    const sortalElements = this.getSortalElements(classElement, []);
+    const hasNoSortal = sortalElements.length === 0;
+    const elementName = classElement.name || classElement.uri;
+    const elementStereotypeName = this._rules.getStereotypeNameByURI(
+      classElement.stereotypes[0],
+    );
+
+    if (hasNoSortal) {
+      const errorDetail = `Must be a sortal S that specializes "${elementName}" of stereotype ${elementStereotypeName}, or specializes a non-sortal supertype common to both "${elementName}" and S.
+      )}`;
+
+      this._errors.push(
+        new OntoUMLSpecializationError(errorDetail, {
+          structuralElement: classElement,
+        }),
+      );
+    }
+
+    return true;
+  }
+
+  getSortalElements(
+    classElement: IStructuralElement,
+    sortalElements: IStructuralElement[],
+  ): IStructuralElement[] {
+    const sortalStereotypesURI = this._rules.getStereotypesURI({
+      sortality: SORTAL,
+    });
+    const children = this._parser.getClassChildren(classElement.uri);
+
+    for (let i = 0; i < children.length; i += 1) {
+      const childElement = children[i];
+      const childStereotype = childElement.stereotypes[0];
+
+      if (sortalStereotypesURI.includes(childStereotype)) {
+        sortalElements.push(childElement);
+      } else {
+        return [
+          ...sortalElements,
+          ...this.getSortalElements(childElement, sortalElements),
+        ];
+      }
+    }
+
+    return sortalElements;
+  }
+
+  // A Sortal element must specialize only 1 Ultimate Sortal element
+  async verifySortalitySpecializations(classElement: IStructuralElement) {
+    const ultimateElements = this.getUltimateSortalElements(classElement, []);
+    const ultimateSortalStereotypesName = this._rules.getStereotypesName({
+      sortality: SORTAL,
+      ultimateSortal: true,
+    });
+    const elementName = classElement.name || classElement.uri;
+    const elementStereotypeName = this._rules.getStereotypeNameByURI(
+      classElement.stereotypes[0],
+    );
+
+    if (ultimateElements.length === 0) {
+      const errorDetail = `Class "${elementName}" of stereotype ${elementStereotypeName} must specialialize an ultimate sortal of stereotype ${ultimateSortalStereotypesName.join(
+        ' or ',
+      )}.`;
+
+      this._errors.push(
+        new OntoUMLSpecializationError(errorDetail, {
+          structuralElement: classElement,
+        }),
+      );
+    } else if (ultimateElements.length > 1) {
+      const ultimateElementsName = ultimateElements.map(
+        (ultimateElement: IStructuralElement) =>
+          ultimateElement.name || ultimateElement.uri,
+      );
+      const errorDetail = `Class "${elementName}" of stereotype ${elementStereotypeName} must specialialize only 1 ultimate sortal (${ultimateElementsName.join(
+        ' or ',
+      )}).`;
+
+      this._errors.push(
+        new OntoUMLSpecializationError(errorDetail, {
+          structuralElement: classElement,
+          ultimateElements,
+        }),
+      );
+    }
+
+    return true;
+  }
+
+  getUltimateSortalElements(
+    classElement: IStructuralElement,
+    ultimateElements: IStructuralElement[],
+  ): IStructuralElement[] {
+    const ultimateSortalStereotypesURI = this._rules.getStereotypesURI({
+      sortality: SORTAL,
+      ultimateSortal: true,
+    });
+    const parents = this._parser.getClassParents(classElement.uri);
+
+    for (let i = 0; i < parents.length; i += 1) {
+      const parentElement = parents[i];
+      const parentStereotype = parentElement.stereotypes[0];
+
+      if (ultimateSortalStereotypesURI.includes(parentStereotype)) {
+        ultimateElements.push(parentElement);
+      } else {
+        return [
+          ...ultimateElements,
+          ...this.getUltimateSortalElements(parentElement, ultimateElements),
+        ];
+      }
+    }
+
+    return ultimateElements;
+  }
+}
+
+export default OntoUMLSyntaxEndurants;

--- a/src/rules/1.0/ontouml.ts
+++ b/src/rules/1.0/ontouml.ts
@@ -1,0 +1,140 @@
+// https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Specialization-Table
+import {
+  RIGID,
+  ANTI_RIGID,
+  SEMI_RIGID,
+  SORTAL,
+  NON_SORTAL,
+} from '@constants/stereotypes_constraints';
+
+const KIND: 'ontouml/1.0/kind' = 'ontouml/1.0/kind';
+const SUBKIND: 'ontouml/1.0/subkind' = 'ontouml/1.0/subkind';
+const RELATOR: 'ontouml/1.0/relator' = 'ontouml/1.0/relator';
+const MODE: 'ontouml/1.0/mode' = 'ontouml/1.0/mode';
+const QUALITY: 'ontouml/1.0/quality' = 'ontouml/1.0/quality';
+const QUANTITY: 'ontouml/1.0/quantity' = 'ontouml/1.0/quantity';
+const COLLECTIVE: 'ontouml/1.0/collective' = 'ontouml/1.0/collective';
+const CATEGORY: 'ontouml/1.0/category' = 'ontouml/1.0/category';
+const ROLE: 'ontouml/1.0/role' = 'ontouml/1.0/role';
+const PHASE: 'ontouml/1.0/phase' = 'ontouml/1.0/phase';
+const MIXIN: 'ontouml/1.0/mixin' = 'ontouml/1.0/mixin';
+const ROLE_MIXIN: 'ontouml/1.0/roleMixin' = 'ontouml/1.0/roleMixin';
+
+export const STEREOTYPES: IStereotype[] = [
+  {
+    name: '«kind»',
+    uri: KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«subkind»',
+    uri: SUBKIND,
+    specializes: [KIND, QUANTITY, COLLECTIVE, SUBKIND, CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«relator»',
+    uri: RELATOR,
+    specializes: [RELATOR],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«mode»',
+    uri: MODE,
+    specializes: [MODE],
+    rigidity: RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«quality»',
+    uri: QUALITY,
+    specializes: [QUALITY],
+    rigidity: RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«quantity»',
+    uri: QUANTITY,
+    specializes: [QUANTITY],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«collective»',
+    uri: COLLECTIVE,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«category»',
+    uri: CATEGORY,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«mixin»',
+    uri: MIXIN,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: SEMI_RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«roleMixin»',
+    uri: ROLE_MIXIN,
+    specializes: [CATEGORY, MIXIN, ROLE_MIXIN],
+    rigidity: ANTI_RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«role»',
+    uri: ROLE,
+    specializes: [
+      KIND,
+      QUANTITY,
+      COLLECTIVE,
+      SUBKIND,
+      ROLE,
+      PHASE,
+      MIXIN,
+      ROLE_MIXIN,
+      RELATOR,
+    ],
+    rigidity: ANTI_RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«phase»',
+    uri: PHASE,
+    specializes: [
+      KIND,
+      QUANTITY,
+      COLLECTIVE,
+      SUBKIND,
+      ROLE,
+      PHASE,
+      MIXIN,
+      ROLE_MIXIN,
+      RELATOR,
+    ],
+    rigidity: ANTI_RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+];

--- a/src/rules/2.0/ontouml.ts
+++ b/src/rules/2.0/ontouml.ts
@@ -1,0 +1,164 @@
+// https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Specialization-Table
+import {
+  RIGID,
+  ANTI_RIGID,
+  SEMI_RIGID,
+  SORTAL,
+  NON_SORTAL,
+} from '@constants/stereotypes_constraints';
+
+const KIND: 'ontouml/2.0/kind' = 'ontouml/2.0/kind';
+const QUANTITY_KIND: 'ontouml/2.0/quantityKind' = 'ontouml/2.0/quantityKind';
+const COLLECTIVE_KIND: 'ontouml/2.0/collectiveKind' =
+  'ontouml/2.0/collectiveKind';
+const SUBKIND: 'ontouml/2.0/subkind' = 'ontouml/2.0/subkind';
+const ROLE: 'ontouml/2.0/role' = 'ontouml/2.0/role';
+const PHASE: 'ontouml/2.0/phase' = 'ontouml/2.0/phase';
+const CATEGORY: 'ontouml/2.0/category' = 'ontouml/2.0/category';
+const MIXIN: 'ontouml/2.0/mixin' = 'ontouml/2.0/mixin';
+const ROLE_MIXIN: 'ontouml/2.0/roleMixin' = 'ontouml/2.0/roleMixin';
+const PHASE_MIXIN: 'ontouml/2.0/phaseMixin' = 'ontouml/2.0/phaseMixin';
+const RELATOR_KIND: 'ontouml/2.0/relatorKind' = 'ontouml/2.0/relatorKind';
+const MODE_KIND: 'ontouml/2.0/modeKind' = 'ontouml/2.0/modeKind';
+const QUALITY_KIND: 'ontouml/2.0/qualityKind' = 'ontouml/2.0/qualityKind';
+
+export const STEREOTYPES: IStereotype[] = [
+  {
+    name: '«kind»',
+    uri: KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«quantityKind»',
+    uri: QUANTITY_KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«collectiveKind»',
+    uri: COLLECTIVE_KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«subkind»',
+    uri: SUBKIND,
+    specializes: [
+      KIND,
+      QUANTITY_KIND,
+      COLLECTIVE_KIND,
+      SUBKIND,
+      CATEGORY,
+      MIXIN,
+      RELATOR_KIND,
+      MODE_KIND,
+      QUANTITY_KIND,
+    ],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«role»',
+    uri: ROLE,
+    specializes: [
+      KIND,
+      QUANTITY_KIND,
+      COLLECTIVE_KIND,
+      SUBKIND,
+      ROLE,
+      PHASE,
+      MIXIN,
+      ROLE_MIXIN,
+      PHASE_MIXIN,
+      RELATOR_KIND,
+      MODE_KIND,
+      QUALITY_KIND,
+    ],
+    rigidity: ANTI_RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«phase»',
+    uri: PHASE,
+    specializes: [
+      KIND,
+      QUANTITY_KIND,
+      COLLECTIVE_KIND,
+      SUBKIND,
+      PHASE,
+      MIXIN,
+      PHASE_MIXIN,
+      RELATOR_KIND,
+      MODE_KIND,
+      QUALITY_KIND,
+    ],
+    rigidity: ANTI_RIGID,
+    sortality: SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«category»',
+    uri: CATEGORY,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«mixin»',
+    uri: MIXIN,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: SEMI_RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«roleMixin»',
+    uri: ROLE_MIXIN,
+    specializes: [CATEGORY, MIXIN, ROLE_MIXIN, PHASE_MIXIN],
+    rigidity: ANTI_RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«phaseMixin»',
+    uri: PHASE_MIXIN,
+    specializes: [CATEGORY, MIXIN, PHASE_MIXIN],
+    rigidity: ANTI_RIGID,
+    sortality: NON_SORTAL,
+    ultimateSortal: false,
+  },
+  {
+    name: '«relatorKind»',
+    uri: RELATOR_KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«modeKind»',
+    uri: MODE_KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+  {
+    name: '«qualityKind»',
+    uri: QUALITY_KIND,
+    specializes: [CATEGORY, MIXIN],
+    rigidity: RIGID,
+    sortality: SORTAL,
+    ultimateSortal: true,
+  },
+];

--- a/src/rules/ontouml_rules.ts
+++ b/src/rules/ontouml_rules.ts
@@ -1,0 +1,99 @@
+import memoizee from 'memoizee';
+import * as OntoUMLv1 from './1.0/ontouml';
+import * as OntoUMLv2 from './2.0/ontouml';
+
+interface IFilter {
+  rigidity?: string;
+  sortality?: string;
+  ultimateSortal?: boolean;
+}
+
+class OntoUMLRules {
+  private _stereotypes: IStereotype[];
+  private _version: string;
+
+  constructor(version?: string) {
+    const ontoUMLRules = {
+      '1.0': OntoUMLv1,
+      '2.0': OntoUMLv2,
+    };
+
+    this._stereotypes = ontoUMLRules[version || '1.0'].STEREOTYPES;
+    this._version = version || '1.0';
+
+    this.getStereotypesURI = memoizee(this.getStereotypesURI);
+    this.getSpecializationsConstraints = memoizee(
+      this.getSpecializationsConstraints,
+    );
+  }
+
+  getVersion(): string {
+    return this._version;
+  }
+
+  getStereotypeNameByURI(stereotypeUri: string): string {
+    return this._stereotypes.filter(
+      (stereotype: IStereotype) => stereotype.uri === stereotypeUri,
+    )[0].name;
+  }
+
+  getStereotypesURI(filters?: IFilter): string[] {
+    return this._stereotypes
+      .filter((stereotype: IStereotype) => {
+        let contains = true;
+
+        if (filters) {
+          for (const key of Object.keys(filters)) {
+            contains = contains && filters[key] === stereotype[key];
+          }
+        }
+
+        return contains;
+      })
+      .map((stereotype: IStereotype) => stereotype.uri);
+  }
+
+  getStereotypesName(filters?: IFilter): string[] {
+    return this._stereotypes
+      .filter((stereotype: IStereotype) => {
+        let contains = true;
+
+        if (filters) {
+          for (const key of Object.keys(filters)) {
+            contains = contains && filters[key] === stereotype[key];
+          }
+        }
+
+        return contains;
+      })
+      .map((stereotype: IStereotype) => stereotype.name);
+  }
+
+  getSpecializationsConstraints(): object {
+    const specializationsConstraints = {};
+    const stereotypes = this._stereotypes;
+
+    for (let i = 0; i < stereotypes.length; i += 1) {
+      const stereotype = stereotypes[1];
+
+      specializationsConstraints[stereotype.uri] = stereotype.specializes;
+    }
+
+    return specializationsConstraints;
+  }
+
+  isValidSpecialization(
+    stereotypeUri: string,
+    parentStereotypeUri: string,
+  ): boolean {
+    const stereotype = this._stereotypes.filter(
+      (stereotype: IStereotype) => stereotype.uri === stereotypeUri,
+    )[0];
+
+    return stereotype
+      ? stereotype.specializes.includes(parentStereotypeUri)
+      : false;
+  }
+}
+
+export default OntoUMLRules;

--- a/test_models/README.md
+++ b/test_models/README.md
@@ -1,0 +1,14 @@
+# OntoUML Example Models
+
+Repository with OntoUML models for development tests
+
+## Invalid OntoUML Models
+
+| Model | Version | Valid Model | Valid OntoUML Model | Error Description |
+|:----:|:----:|:----:| :----:| 
+| m1.invalid.json | - | ✅ | ❌| Stereotypes missing |
+| m2.invalid.json | - | ✅ | ❌| Stereotypes missing |
+| m3.invalid.json | `1.0` | ✅ | ❌| Invalid Stereotype |
+| m4.invalid.json | `1.0` | ✅ | ❌| Endurant sortal `role` without specialization |
+| m5.invalid.json | `1.0` | ✅ | ❌| Kind cannot specialize another kind |
+| m6.invalid.json | `1.0` | ✅ | ❌| Non Sortal not specialized by a Sortal. |

--- a/test_models/invalids/index.ts
+++ b/test_models/invalids/index.ts
@@ -1,0 +1,15 @@
+const modelInvalidExample1 = require('./m1.invalid.json');
+const modelInvalidExample2 = require('./m2.invalid.json');
+const modelInvalidExample3 = require('./m3.invalid.json');
+const modelInvalidExample4 = require('./m4.invalid.json');
+const modelInvalidExample5 = require('./m5.invalid.json');
+const modelInvalidExample6 = require('./m6.invalid.json');
+
+export {
+  modelInvalidExample1,
+  modelInvalidExample2,
+  modelInvalidExample3,
+  modelInvalidExample4,
+  modelInvalidExample5,
+  modelInvalidExample6,
+};

--- a/test_models/invalids/m1.invalid.json
+++ b/test_models/invalids/m1.invalid.json
@@ -1,0 +1,54 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/",
+  "url": "https://example.com/model/",
+  "name": "Something Else",
+  "authors": [
+    "Bob",
+    "Dan"
+  ],
+  "structuralElements": [
+    {
+      "@type": "GeneralizationLink",
+      "uri": "ontouml:model.g1",
+      "tuple": [
+        "ontouml:model.p1.c1",
+        "ontouml:model.c2"
+      ]
+    },
+    {
+      "@type": "GeneralizationLink",
+      "uri": "ontouml:model.g2",
+      "tuple": [
+        "ontouml:model.p1.c1",
+        "ontouml:model.c3"
+      ]
+    },
+    {
+      "@type": "Package",
+      "uri": "ontouml:model.p1",
+      "structuralElements": [
+        {
+          "@type": "Class",
+          "uri": "ontouml:model.p1.c1"
+        }
+      ]
+    },
+    {
+      "@type": "Class",
+      "uri": "ontouml:model.c2"
+    },
+    {
+      "@type": "Class",
+      "uri": "ontouml:model.c3"
+    },
+    {
+      "@type": "GeneralizationSet",
+      "uri": "ontouml:gs1",
+      "tuple": [
+        "ontouml:model.g1",
+        "ontouml:model.g2"
+      ]
+    }
+  ]
+}

--- a/test_models/invalids/m2.invalid.json
+++ b/test_models/invalids/m2.invalid.json
@@ -1,0 +1,164 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/m2",
+  "url": "https://example.com/model/m2",
+  "name": "Something Else",
+  "authors": [
+    "Bob",
+    "Dan"
+  ],
+  "structuralElements": [
+    {
+      "@type": "Package",
+      "uri": "ontouml:model.p1",
+      "name": "clean model package",
+      "structuralElements": [
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:model.g1",
+          "tuple": [
+            "ontouml:model.p1.c1",
+            "ontouml:model.c2"
+          ]
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:model.g2",
+          "tuple": [
+            "ontouml:model.p1.c1",
+            "ontouml:model.c3"
+          ]
+        },
+        {
+          "@type": "Class",
+          "uri": "ontouml:model.p1.c1"
+        },
+        {
+          "@type": "Class",
+          "uri": "ontouml:model.c2"
+        },
+        {
+          "@type": "Class",
+          "uri": "ontouml:model.c3"
+        },
+        {
+          "@type": "GeneralizationSet",
+          "uri": "ontouml:gs1",
+          "tuple": [
+            "ontouml:model.g1",
+            "ontouml:model.g2"
+          ]
+        }
+      ]
+    },
+
+    {
+      "@type": "Package",
+      "uri": "ontouml:pkg.cyclical.hierarchy.1",
+      "name": "cyclical model package",
+      "structuralElements": [
+        {
+          "@type": "Class",
+          "uri": "ontouml:cycle1",
+          "name": "Ring one of cycle"
+        },
+        {
+          "@type": "Class",
+          "uri": "ontouml:cycle2",
+          "name": "Ring two of cycle"
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:cycle.g1",
+          "tuple": [
+            "ontouml:cycle1",
+            "ontouml:cycle2"
+          ]
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:cycle.g2",
+          "tuple": [
+            "ontouml:cycle2",
+            "ontouml:cycle1"
+          ]
+        }
+      ]
+    },
+
+    {
+      "@type": "Package",
+      "uri": "ontouml:pkg.missmatching.generalization.1",
+      "name": "missmatching generalization model package",
+      "structuralElements": [
+        {
+          "@type": "Class",
+          "uri": "ontouml:miss.c1",
+          "name": "Miss Class"
+        },
+        {
+          "@type": "Package",
+          "uri": "ontouml:miss.p1",
+          "name": "Miss Package"
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:missmatching.g1",
+          "tuple": [
+            "ontouml:miss.c1",
+            "ontouml:miss.p1"
+          ]
+        }
+      ]
+    },
+
+    {
+      "@type": "Package",
+      "uri": "ontouml:pkg.matching.general.gs.1",
+      "name": "cyclical model package",
+      "structuralElements": [
+        {
+          "@type": "Class",
+          "uri": "ontouml:general.1",
+          "name": "General Class 1"
+        },
+        {
+          "@type": "Class",
+          "uri": "ontouml:general.2",
+          "name": "General Class 2"
+        },
+        {
+
+          "@type": "Class",
+          "uri": "ontouml:specific",
+          "name": "Specific Class"
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:matching.g1",
+          "tuple": [
+            "ontouml:general.1",
+            "ontouml:specific"
+          ]
+        },
+        {
+          "@type": "GeneralizationLink",
+          "uri": "ontouml:matching.g2",
+          "tuple": [
+            "ontouml:general.2",
+            "ontouml:specific"
+          ]
+        },
+        {
+          "@type": "GeneralizationSet",
+          "uri": "ontouml:matching.gs1",
+          "tuple": [
+            "ontouml:matching.g1",
+            "ontouml:matching.g2"
+          ]
+        }
+      ]
+    }
+
+  ]
+}

--- a/test_models/invalids/m3.invalid.json
+++ b/test_models/invalids/m3.invalid.json
@@ -1,0 +1,24 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/m3",
+  "url": "https://example.com/model/m3",
+  "name": "Invalid stereotype model",
+  "structuralElements": [
+      {
+          "@type": "Class",
+          "name": "Person",
+          "uri": "model:#/class/Person",
+          "stereotypes": [
+              "ontouml/1.0/kind"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Machine",
+          "uri": "model:#/class/Machine",
+          "stereotypes": [
+              "ontouml/1.0/machine"
+          ]
+      }
+  ]
+}

--- a/test_models/invalids/m4.invalid.json
+++ b/test_models/invalids/m4.invalid.json
@@ -1,0 +1,24 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/m4",
+  "url": "https://example.com/model/m4",
+  "name": "Endurant sortal <<role>> without specialization",
+  "structuralElements": [
+      {
+          "@type": "Class",
+          "name": "Person",
+          "uri": "model:#/class/Person",
+          "stereotypes": [
+              "ontouml/1.0/kind"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Teacher",
+          "uri": "model:#/class/Teacher",
+          "stereotypes": [
+              "ontouml/1.0/role"
+          ]
+      }
+  ]
+}

--- a/test_models/invalids/m5.invalid.json
+++ b/test_models/invalids/m5.invalid.json
@@ -1,0 +1,32 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/m5",
+  "url": "https://example.com/model/m5",
+  "name": "Kind cannot specialize another kind.",
+  "structuralElements": [
+      {
+          "@type": "Class",
+          "name": "Person",
+          "uri": "model:#/class/Person",
+          "stereotypes": [
+              "ontouml/1.0/kind"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Machine",
+          "uri": "model:#/class/Machine",
+          "stereotypes": [
+              "ontouml/1.0/kind"
+          ]
+      },
+      {
+        "@type": "GeneralizationLink",
+        "uri": "model:#/generalization/PersonMachine",
+        "tuple": [
+            "model:#/class/Person",
+            "model:#/class/Machine"
+        ]
+    }
+  ]
+}

--- a/test_models/invalids/m6.invalid.json
+++ b/test_models/invalids/m6.invalid.json
@@ -1,0 +1,24 @@
+{
+  "@type": "Model",
+  "uri": "https://example.com/model/m6",
+  "url": "https://example.com/model/m6",
+  "name": "Non Sortal not specialized by a Sortal.",
+  "structuralElements": [
+      {
+          "@type": "Class",
+          "name": "Person",
+          "uri": "model:#/class/Person",
+          "stereotypes": [
+              "ontouml/1.0/kind"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Agent",
+          "uri": "model:#/class/Agent",
+          "stereotypes": [
+              "ontouml/1.0/mixin"
+          ]
+      }
+  ]
+}

--- a/test_models/valids/index.ts
+++ b/test_models/valids/index.ts
@@ -1,0 +1,3 @@
+const modelValidExample1 = require('./m1.valid.json');
+
+export { modelValidExample1 };

--- a/test_models/valids/m1.valid.json
+++ b/test_models/valids/m1.valid.json
@@ -1,0 +1,215 @@
+{
+  "@type": "Model",
+  "uri": "https://ontouml.org/archive/sales2018towards",
+  "authors": [
+      "Sales, Tiago Prince",
+      "Guarino, Nicola",
+      "Guizzardi, Giancarlo",
+      "Mylopoulos, John"
+  ],
+  "name": "Towards an Ontology of Competition",
+  "structuralElements": [
+      {
+          "@type": "Class",
+          "name": "Agent",
+          "uri": "model:#/class/Agent",
+          "stereotypes": [
+              "ontouml/1.0/category"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Competitor",
+          "uri": "model:#/class/Competitor",
+          "stereotypes": [
+              "ontouml/1.0/roleMixin"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/AgentCompetitor",
+          "tuple": [
+              "model:#/class/Agent",
+              "model:#/class/Competitor"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "ResourceDemand",
+          "uri": "model:#/class/ResourceDemand",
+          "stereotypes": [
+              "ontouml/1.0/mode"
+          ],
+          "properties": [
+              {
+                  "@type": "Property",
+                  "name": "quantity",
+                  "uri":"model:#/property/quantity"
+              }
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Collective Demand",
+          "uri": "model:#/class/CollectiveDemand",
+          "stereotypes": [
+              "ontouml/1.0/relator"
+          ],
+          "properties": [
+              {
+                  "@type": "Property",
+                  "name": "/collective quantity",
+                  "uri":"model:#/property/collectiveQuantity"
+              },
+              {
+                  "@type": "Property",
+                  "name": "/competitiviness",
+                  "uri":"model:#/property/competitiviness"
+              }
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Competition",
+          "uri": "model:#/class/Competition",
+          "stereotypes": [
+              "ontouml/1.0/phase"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Non-Competition",
+          "uri": "model:#/class/Non-Competition",
+          "stereotypes": [
+              "ontouml/1.0/phase"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/CollectiveDemandCompetition",
+          "tuple": [
+              "model:#/class/CollectiveDemand",
+              "model:#/class/Competition"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/CollectiveDemandNon-Competition",
+          "tuple": [
+              "model:#/class/CollectiveDemand",
+              "model:#/class/Non-Competition"
+          ]
+      },
+      {
+          "@type": "GeneralizationSet",
+          "uri": "model:#/generalizationSet/CollectiveDemandCompetitionNon-Competition",
+          "isDisjoint": true,
+          "isComplete": true,
+          "tuple": [
+              "model:#/generalization/CollectiveDemandCompetition",
+              "model:#/generalization/CollectiveDemandNon-Competition"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Resource",
+          "uri": "model:#/class/Resource",
+          "stereotypes": [
+              "ontouml/1.0/mixin"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Scarce Resoure",
+          "uri": "model:#/class/ScarceResource",
+          "stereotypes": [
+              "ontouml/1.0/roleMixin"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/ResourceScarceResource",
+          "tuple": [
+              "model:#/class/Resource",
+              "model:#/class/ScarceResource"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Single Resource",
+          "uri": "model:#/class/SingleResource",
+          "stereotypes": [
+              "ontouml/1.0/roleMixin"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Resource Type",
+          "uri": "model:#/class/ResourceType",
+          "stereotypes": [
+              "uml/powertype"
+          ]
+      },
+      {
+          "@type": "Class",
+          "name": "Resource Stock",
+          "uri": "model:#/class/ResourceStock",
+          "stereotypes": [
+              "ontouml/1.0/collective"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/ResourceSingleResource",
+          "tuple": [
+              "model:#/class/Resource",
+              "model:#/class/SingleResource"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/ResourceResourceType",
+          "tuple": [
+              "model:#/class/Resource",
+              "model:#/class/ResourceType"
+          ]
+      },
+      {
+          "@type": "GeneralizationLink",
+          "uri": "model:#/generalization/ResourceResourceStock",
+          "tuple": [
+              "model:#/class/Resource",
+              "model:#/class/ResourceStock"
+          ]
+      },
+      {
+          "@type": "GeneralizationSet",
+          "uri": "model:#/generalizationSet/ResourceSingleResourceResourceTypeResourceStock",
+          "tuple": [
+              "model:#/generalization/ResourceSingleResource",
+              "model:#/generalization/ResourceResourceType",
+              "model:#/generalization/ResourceResourceStock"
+          ]
+      },
+      {
+          "@type": "Relation",
+          "uri": "model:#/relation/ResourceDemandCollectiveDemand",
+          "properties": [
+              {
+                  "@type": "Property",
+                  "uri":"model:#/property/ResourceDemand",
+                  "propertyType": "model:#/class/ResourceDemand",
+                  "lowerbound": 2,
+                  "upperbound": "*"
+              },
+              {
+                  "@type": "Property",
+                  "uri":"model:#/property/CollectiveDemand",
+                  "propertyType": "model:#/class/CollectiveDemand",
+                  "lowerbound": 0,
+                  "upperbound": "*"
+              }
+          ]
+      }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,11 @@
     "typeRoots" : ["./@types", "./node_modules/@types"],
     "baseUrl": ".",
     "paths": {
+      "@test-models/*": ["test_models/*"],
       "@constants/*": ["src/constants/*"],
+      "@error/*": ["src/error/*"],
       "@libs/*": ["src/libs/*"],
+      "@rules/*": ["src/rules/*"],
       "@schemas/*": ["schemas/*"],
       "@utils/*": ["src/utils/*"]
     }


### PR DESCRIPTION
This PR adds:

- [x] OntoUML Parser
- [x] OntoUML Syntax validation for endurants
- [x] Error system
- [x] Rules system

# Example of errors

```javascript
// OntoUML Stereotype Error
OntoUMLStereotypeError {
        id: '4wexw1xxuk40pcgsu',
        code: 'ontouml_stereotype_error',
        title: 'OntoUML Stereotype Error',
        detail: 'Class "ontouml:model.c2" must contain 1 stereotype.',
        links:
         { self:
            'https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Syntax-Constraints' },
        meta: { structuralElement: [Object] }
}

// OntoUML Specialization Error
OntoUMLSpecializationError {
        id: '4wexw1xxuk40pdm5g',
        code: 'ontouml_specialization_error',
        title: 'OntoUML Specialization Error',
        detail:
         'Class "Machine" of stereotype «kind» can not specialize "Person" of stereotype «kind».',
        links:
         { self:
            'https://github.com/OntoUML/ontouml-js/wiki/OntoUML-Specialization-Table' },
        meta: { structuralElement: [Object], parentElement: [Object] } 
}
```

