### PR TITLE
[fix] Fix inconsistent in Datatypes with attributes

### DIFF
--- a/__tests__/libs/ontuml2gufo/attributes.test.ts
+++ b/__tests__/libs/ontuml2gufo/attributes.test.ts
@@ -29,4 +29,21 @@ describe('Attributes', () => {
     expect(result).toContain('<:description> <rdfs:range> <xsd:string>');
     expect(result).toContain('<:description> <rdfs:label> "description"');
   });
+
+  it('should generate attributes of datatypes classes without rdfs:subPropertyOf gufo:hasQualityValue', async () => {
+    expect(result).toContain('<:lower> <rdf:type> <owl:DatatypeProperty>');
+    expect(result).not.toContain(
+      '<:lower> <rdfs:subPropertyOf> <gufo:hasQualityValue>',
+    );
+  });
+
+  it('should generate attributes of stereotype classes with rdfs:subPropertyOf gufo:hasQualityValue', async () => {
+    expect(result).toContain('<:area> <rdf:type> <owl:DatatypeProperty>');
+    expect(result).toContain(
+      '<:area> <rdfs:subPropertyOf> <gufo:hasQualityValue>',
+    );
+    expect(result).toContain('<:area> <rdfs:domain> <:GeospatialFeature>');
+    expect(result).toContain('<:area> <rdfs:range> <xsd:int>');
+    expect(result).toContain('<:area> <rdfs:label> "area"');
+  });
 });

--- a/__tests__/libs/ontuml2gufo/examples.test.ts
+++ b/__tests__/libs/ontuml2gufo/examples.test.ts
@@ -22,21 +22,34 @@ describe('Examples', () => {
       {
         name: 'alpinebits.ttl',
         model: alpinebits,
-        options: { format: 'Turtle' },
+        options: { 
+          format: 'Turtle',
+          baseIRI: 'https://alpinebits.org'
+
+        },
       },
       {
         name: 'alpinebits.nt',
         model: alpinebits,
+        options: { 
+          baseIRI: 'https://alpinebits.org'
+        }
       },
       {
         name: 'istandard.ttl',
         model: istandard,
-        options: { format: 'Turtle' },
+        options: { 
+          format: 'Turtle',
+          baseIRI: 'https://istandaarden.nl'
+        },
       },
       {
         name: 'istandardMultiplePackages.ttl',
         model: istandard,
-        options: { format: 'Turtle', prefixPackages: true },
+        options: { 
+          format: 'Turtle',
+          baseIRI: 'https://istandaarden.nl', 
+          prefixPackages: true },
       },
       {
         name: 'person.ttl',


### PR DESCRIPTION
#### Introduction

This PR fixes #21 

#### Output

```
:lower rdf:type owl:DatatypeProperty;
    rdfs:domain :Range;
    rdfs:range xsd:int;
    rdfs:label "lower".
```