### PR TITLE
Ease schema requirements and constraints

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/__tests__/libs/ontouml/natures.test.ts
+++ b/__tests__/libs/ontouml/natures.test.ts
@@ -1,0 +1,68 @@
+import { natureUtils, OntologicalNature } from '@libs/ontouml';
+
+describe(`Test ontological nature handling utility`, () => {
+  describe('Test natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.Natures).toHaveLength(11));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.Natures).toContain(OntologicalNature.functional_complex);
+      expect(natureUtils.Natures).toContain(OntologicalNature.collective);
+      expect(natureUtils.Natures).toContain(OntologicalNature.quantity);
+      expect(natureUtils.Natures).toContain(OntologicalNature.relator);
+      expect(natureUtils.Natures).toContain(OntologicalNature.intrinsic_mode);
+      expect(natureUtils.Natures).toContain(OntologicalNature.extrinsic_mode);
+      expect(natureUtils.Natures).toContain(OntologicalNature.quality);
+      expect(natureUtils.Natures).toContain(OntologicalNature.event);
+      expect(natureUtils.Natures).toContain(OntologicalNature.situation);
+      expect(natureUtils.Natures).toContain(OntologicalNature.type);
+      expect(natureUtils.Natures).toContain(OntologicalNature.abstract);
+    });
+  });
+
+  describe('Test endurant natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.EndurantNatures).toHaveLength(7));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.functional_complex);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.collective);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.quantity);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.relator);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.intrinsic_mode);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.extrinsic_mode);
+      expect(natureUtils.EndurantNatures).toContain(OntologicalNature.quality);
+    });
+  });
+
+  describe('Test substantial natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.SubstantialNatures).toHaveLength(3));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.SubstantialNatures).toContain(OntologicalNature.functional_complex);
+      expect(natureUtils.SubstantialNatures).toContain(OntologicalNature.collective);
+      expect(natureUtils.SubstantialNatures).toContain(OntologicalNature.quantity);
+    });
+  });
+
+  describe('Test moment natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.MomentNatures).toHaveLength(4));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.MomentNatures).toContain(OntologicalNature.relator);
+      expect(natureUtils.MomentNatures).toContain(OntologicalNature.intrinsic_mode);
+      expect(natureUtils.MomentNatures).toContain(OntologicalNature.extrinsic_mode);
+      expect(natureUtils.MomentNatures).toContain(OntologicalNature.quality);
+    });
+  });
+
+  describe('Test intrinsic moment natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.IntrinsicMomentNatures).toHaveLength(2));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.IntrinsicMomentNatures).toContain(OntologicalNature.intrinsic_mode);
+      expect(natureUtils.IntrinsicMomentNatures).toContain(OntologicalNature.quality);
+    });
+  });
+
+  describe('Test extrinsic moment natures array', () => {
+    it('There should be a know number of natures', () => expect(natureUtils.ExtrinsicMomentNatures).toHaveLength(2));
+    it('Each of these must be a in the array', () => {
+      expect(natureUtils.ExtrinsicMomentNatures).toContain(OntologicalNature.extrinsic_mode);
+      expect(natureUtils.ExtrinsicMomentNatures).toContain(OntologicalNature.relator);
+    });
+  });
+});

--- a/__tests__/libs/ontouml/schema.test.ts
+++ b/__tests__/libs/ontouml/schema.test.ts
@@ -22,7 +22,7 @@ import {
 
 describe('Schema tests', () => {
   describe(`Test valid serializations of '${OntoumlElement.name}' objects against JSON Schema, but parsing fails where references cannot be resolved.`, () => {
-    it(`Test valid ${ClassView.name} objects.`, () => {
+    describe(`Test valid ${ClassView.name} objects.`, () => {
       const classReference = {
         type: 'Class',
         id: 'modelElement'
@@ -59,16 +59,21 @@ describe('Schema tests', () => {
         modelElement: classReference
       };
 
-      expect(serializationUtils.typeToSchemaId['ClassView']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/ClassView');
-      expect(serializationUtils.validate(classView1)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(classView1))).toThrow();
-      expect(serializationUtils.validate(classView2)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(classView2))).toThrow();
-      expect(serializationUtils.validate(classView3)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(classView3))).toThrow();
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['ClassView']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/ClassView'));
+      it('Minimal views should be valid', () => {
+        expect(serializationUtils.validate(classView1)).toBe(true);
+        expect(serializationUtils.validate(classView2)).toBe(true);
+        expect(serializationUtils.validate(classView3)).toBe(true);
+      });
+      it('Minimal views should throw an exception due to references to non-existing elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(classView1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(classView2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(classView3))).toThrow();
+      });
     });
 
-    it(`Test valid ${GeneralizationSetView.name} objects`, () => {
+    describe(`Test valid ${GeneralizationSetView.name} objects`, () => {
       const gsReference = {
         type: 'GeneralizationSet',
         id: 'modelElement'
@@ -105,18 +110,23 @@ describe('Schema tests', () => {
         modelElement: gsReference
       };
 
-      expect(serializationUtils.typeToSchemaId['GeneralizationSetView']).toBe(
-        'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationSetView'
-      );
-      expect(serializationUtils.validate(gsView1)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(gsView1))).toThrow();
-      expect(serializationUtils.validate(gsView2)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(gsView2))).toThrow();
-      expect(serializationUtils.validate(gsView3)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(gsView3))).toThrow();
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['GeneralizationSetView']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationSetView'
+        ));
+      it('Minimal views should be valid', () => {
+        expect(serializationUtils.validate(gsView1)).toBe(true);
+        expect(serializationUtils.validate(gsView2)).toBe(true);
+        expect(serializationUtils.validate(gsView3)).toBe(true);
+      });
+      it('Minimal views should throw an exception due to references to non-existing elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(gsView1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(gsView2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(gsView3))).toThrow();
+      });
     });
 
-    it(`Test valid ${GeneralizationView.name} objects`, () => {
+    describe(`Test valid ${GeneralizationView.name} objects`, () => {
       const genReference = {
         type: 'Generalization',
         id: 'genReference'
@@ -168,15 +178,672 @@ describe('Schema tests', () => {
         target: targetReference
       };
 
-      expect(serializationUtils.typeToSchemaId['GeneralizationView']).toBe(
-        'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationView'
-      );
-      expect(serializationUtils.validate(genView1)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(genView1))).toThrow();
-      expect(serializationUtils.validate(genView2)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(genView2))).toThrow();
-      expect(serializationUtils.validate(genView3)).toBe(true);
-      expect(() => serializationUtils.parse(JSON.stringify(genView3))).toThrow();
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['GeneralizationView']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationView'
+        ));
+      it('Minimal views should be valid', () => {
+        expect(serializationUtils.validate(genView1)).toBe(true);
+        expect(serializationUtils.validate(genView2)).toBe(true);
+        expect(serializationUtils.validate(genView3)).toBe(true);
+      });
+      it('Minimal views should throw an exception due to references to non-existing elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(genView1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(genView2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(genView3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${PackageView.name} objects`, () => {
+      const pkgReference = {
+        type: 'Package',
+        id: 'pkgReference'
+      };
+
+      const pkgView1 = {
+        type: 'PackageView',
+        id: 'pkgView1',
+        modelElement: pkgReference
+      };
+      const pkgView2 = {
+        type: 'PackageView',
+        id: 'pkgView2',
+        name: 'pkgView2',
+        description: 'pkgView2',
+        shape: {
+          type: 'Rectangle',
+          id: 'pkgView2_shape'
+        },
+        modelElement: pkgReference
+      };
+      const pkgView3 = {
+        type: 'PackageView',
+        id: 'pkgView3',
+        name: {
+          en: 'pkgView3'
+        },
+        description: {
+          en: 'pkgView3'
+        },
+        shape: {
+          type: 'Rectangle',
+          id: 'pkgView3_shape'
+        },
+        modelElement: pkgReference
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['PackageView']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/PackageView'
+        ));
+      it('Minimal views should be valid', () => {
+        expect(serializationUtils.validate(pkgView1)).toBe(true);
+        expect(serializationUtils.validate(pkgView2)).toBe(true);
+        expect(serializationUtils.validate(pkgView3)).toBe(true);
+      });
+      it('Minimal views should throw an exception due to references to non-existing elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(pkgView1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(pkgView2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(pkgView3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${RelationView.name} objects`, () => {
+      const relReference = {
+        type: 'Relation',
+        id: 'genReference'
+      };
+      const sourceReference = {
+        type: 'ClassView',
+        id: 'sourceReference'
+      };
+      const targetReference = {
+        type: 'ClassView',
+        id: 'targetReference'
+      };
+
+      const relView1 = {
+        type: 'RelationView',
+        id: 'relView1',
+        modelElement: relReference,
+        source: sourceReference,
+        target: targetReference
+      };
+      const relView2 = {
+        type: 'RelationView',
+        id: 'relView2',
+        name: 'relView2',
+        description: 'relView2',
+        shape: {
+          type: 'Path',
+          id: 'relView2_shape'
+        },
+        modelElement: relReference,
+        source: sourceReference,
+        target: targetReference
+      };
+      const relView3 = {
+        type: 'RelationView',
+        id: 'relView3',
+        name: {
+          en: 'relView3'
+        },
+        description: {
+          en: 'relView3'
+        },
+        shape: {
+          type: 'Path',
+          id: 'relView3_shape'
+        },
+        modelElement: relReference,
+        source: sourceReference,
+        target: targetReference
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['RelationView']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/RelationView'
+        ));
+      it('Minimal views should be valid', () => {
+        expect(serializationUtils.validate(relView1)).toBe(true);
+        expect(serializationUtils.validate(relView2)).toBe(true);
+        expect(serializationUtils.validate(relView3)).toBe(true);
+      });
+      it('Minimal views should throw an exception due to references to non-existing elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(relView1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(relView2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(relView3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${Path.name} objects`, () => {
+      const pathShape1 = {
+        type: 'Path',
+        id: 'pathShape1'
+      };
+      const pathShape2 = {
+        type: 'Path',
+        id: 'pathShape2',
+        name: 'pathShape2',
+        description: 'pathShape2',
+        points: [{ x: null, y: null }]
+      };
+      const pathShape3 = {
+        type: 'Path',
+        id: 'pathShape3',
+        name: { en: 'pathShape3' },
+        description: { en: 'pathShape3' },
+        points: [{ x: 0, y: 0 }]
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Path']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/PathShape'));
+      it('Minimal shapes should be valid', () => {
+        expect(serializationUtils.validate(pathShape1)).toBe(true);
+        expect(serializationUtils.validate(pathShape2)).toBe(true);
+        expect(serializationUtils.validate(pathShape3)).toBe(true);
+      });
+      it("Minimal shapes should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(pathShape1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(pathShape2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(pathShape3))).not.toThrow();
+      });
+    });
+
+    describe(`Test valid ${Rectangle.name} objects`, () => {
+      const rectangleShape1 = {
+        type: 'Rectangle',
+        id: 'rectangleShape1'
+      };
+      const rectangleShape2 = {
+        type: 'Rectangle',
+        id: 'rectangleShape2',
+        name: 'rectangleShape2',
+        description: 'rectangleShape2',
+        x: null,
+        y: null,
+        width: null,
+        height: null
+      };
+      const rectangleShape3 = {
+        type: 'Rectangle',
+        id: 'rectangleShape3',
+        name: { en: 'rectangleShape3' },
+        description: { en: 'rectangleShape3' },
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Rectangle']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/RectangleShape'
+        ));
+      it('Minimal shapes should be valid', () => {
+        expect(serializationUtils.validate(rectangleShape1)).toBe(true);
+        expect(serializationUtils.validate(rectangleShape2)).toBe(true);
+        expect(serializationUtils.validate(rectangleShape3)).toBe(true);
+      });
+      it("Minimal shapes should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(rectangleShape1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(rectangleShape2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(rectangleShape3))).not.toThrow();
+      });
+    });
+
+    describe(`Test valid ${Text.name} objects`, () => {
+      const textShape1 = {
+        type: 'Text',
+        id: 'textShape1'
+      };
+      const textShape2 = {
+        type: 'Text',
+        id: 'textShape2',
+        name: 'textShape2',
+        description: 'textShape2',
+        x: null,
+        y: null,
+        width: null,
+        height: null
+      };
+      const textShape3 = {
+        type: 'Text',
+        id: 'textShape3',
+        name: { en: 'textShape3' },
+        description: { en: 'textShape3' },
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Text']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/TextShape'));
+      it('Minimal shapes should be valid', () => {
+        expect(serializationUtils.validate(textShape1)).toBe(true);
+        expect(serializationUtils.validate(textShape2)).toBe(true);
+        expect(serializationUtils.validate(textShape3)).toBe(true);
+      });
+      it("Minimal shapes should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(textShape1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(textShape2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(textShape3))).not.toThrow();
+      });
+    });
+
+    describe(`Test valid ${Diagram.name} objects`, () => {
+      const ownerReference = {
+        type: 'Package',
+        id: 'owner'
+      };
+
+      const diagram1 = {
+        type: 'Diagram',
+        id: 'diagram1'
+      };
+      const diagram2 = {
+        type: 'Diagram',
+        id: 'diagram2',
+        name: 'diagram2',
+        description: 'diagram2',
+        contents: null,
+        owner: null
+      };
+      const diagram3 = {
+        type: 'Diagram',
+        id: 'diagram3',
+        name: { en: 'diagram3' },
+        description: { en: 'diagram3' },
+        contents: [],
+        owner: ownerReference
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Diagram']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Diagram'));
+      it('Minimal diagrams should be valid', () => {
+        expect(serializationUtils.validate(diagram1)).toBe(true);
+        expect(serializationUtils.validate(diagram2)).toBe(true);
+        expect(serializationUtils.validate(diagram3)).toBe(true);
+      });
+      it("Minimal diagrams should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(diagram1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(diagram2))).not.toThrow();
+      });
+      it('Minimal generalization sets should throw an exception due to broken references to elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(diagram3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${Class.name} objects`, () => {
+      const class1 = {
+        type: 'Class',
+        id: 'class1'
+      };
+      const class2 = {
+        type: 'Class',
+        id: 'class2',
+        name: 'class2',
+        description: 'class2',
+        propertyAssignments: null,
+        stereotype: null,
+        isAbstract: null,
+        isDerived: null,
+        properties: null,
+        literals: null,
+        restrictedTo: null,
+        isExtensional: null,
+        isPowertype: null,
+        order: null
+      };
+      const class3 = {
+        type: 'Class',
+        id: 'class3',
+        name: { en: 'class3' },
+        description: { en: 'class3' },
+        propertyAssignments: { someTag: true },
+        stereotype: 'type',
+        isAbstract: true,
+        isDerived: false,
+        properties: [],
+        literals: [],
+        restrictedTo: [],
+        isExtensional: true,
+        isPowertype: false,
+        order: '*'
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Class']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Class'));
+      it('Minimal classes should be valid', () => {
+        expect(serializationUtils.validate(class1)).toBe(true);
+        expect(serializationUtils.validate(class2)).toBe(true);
+        expect(serializationUtils.validate(class3)).toBe(true);
+      });
+      it("Minimal classes should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(class1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(class2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(class3))).not.toThrow();
+      });
+    });
+
+    describe(`Test valid ${GeneralizationSet.name} objects`, () => {
+      const categorizerReference = {
+        type: 'Class',
+        id: 'categorizer'
+      };
+
+      const generalizationSet1 = {
+        type: 'GeneralizationSet',
+        id: 'generalizationSet1'
+      };
+      const generalizationSet2 = {
+        type: 'GeneralizationSet',
+        id: 'generalizationSet2',
+        name: 'generalizationSet2',
+        description: 'generalizationSet2',
+        propertyAssignments: null,
+        isDisjoint: null,
+        isComplete: null,
+        categorizer: null,
+        generalizations: null
+      };
+      const generalizationSet3 = {
+        type: 'GeneralizationSet',
+        id: 'generalizationSet3',
+        name: { en: 'generalizationSet3' },
+        description: { en: 'generalizationSet3' },
+        propertyAssignments: { someTag: true },
+        isDisjoint: false,
+        isComplete: true,
+        categorizer: categorizerReference,
+        generalizations: []
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['GeneralizationSet']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationSet'
+        ));
+      it('Minimal generalization sets should be valid', () => {
+        expect(serializationUtils.validate(generalizationSet1)).toBe(true);
+        expect(serializationUtils.validate(generalizationSet2)).toBe(true);
+        expect(serializationUtils.validate(generalizationSet3)).toBe(true);
+      });
+      it("Minimal generalization sets should not throw an exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(generalizationSet1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(generalizationSet2))).not.toThrow();
+      });
+      it('Minimal generalization sets should throw an exception due to broken references to elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(generalizationSet3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${Generalization.name} objects`, () => {
+      const generalReference = {
+        type: 'Class',
+        id: 'general'
+      };
+      const specificReference = {
+        type: 'Class',
+        id: 'specific'
+      };
+
+      const generalization1 = {
+        type: 'Generalization',
+        id: 'generalization1',
+        general: generalReference,
+        specific: specificReference
+      };
+      const generalization2 = {
+        type: 'Generalization',
+        id: 'generalization2',
+        name: 'generalization2',
+        description: 'generalization2',
+        propertyAssignments: null,
+        general: generalReference,
+        specific: specificReference
+      };
+      const generalization3 = {
+        type: 'Generalization',
+        id: 'generalization3',
+        name: { en: 'generalization3' },
+        description: { en: 'generalization3' },
+        propertyAssignments: { someTag: true },
+        general: generalReference,
+        specific: specificReference
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Generalization']).toBe(
+          'https://ontouml.org/ontouml-schema/2021-02-26/Generalization'
+        ));
+      it('Minimal generalizations should be valid', () => {
+        expect(serializationUtils.validate(generalization1)).toBe(true);
+        expect(serializationUtils.validate(generalization2)).toBe(true);
+        expect(serializationUtils.validate(generalization3)).toBe(true);
+      });
+      // it("Minimal generalizations should not throw a }n exception as they don't have broken references to elements", () => {
+      // });
+      it('Minimal generalizations should throw an exception due to broken references to elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(generalization1))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(generalization2))).toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(generalization3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${Literal.name} objects`, () => {
+      const literal1 = {
+        type: 'Literal',
+        id: 'literal1'
+      };
+      const literal2 = {
+        type: 'Literal',
+        id: 'literal2',
+        name: 'literal2',
+        description: 'literal2',
+        propertyAssignments: null
+      };
+      const literal3 = {
+        type: 'Literal',
+        id: 'literal3',
+        name: { en: 'literal3' },
+        description: { en: 'literal3' },
+        propertyAssignments: { someTag: true }
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Literal']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Literal'));
+      it('Minimal literals should be valid', () => {
+        expect(serializationUtils.validate(literal1)).toBe(true);
+        expect(serializationUtils.validate(literal2)).toBe(true);
+        expect(serializationUtils.validate(literal3)).toBe(true);
+      });
+      it("Minimal literals should not throw a }n exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(literal1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(literal2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(literal3))).not.toThrow();
+      });
+      // it('Minimal literals should throw an exception due to broken references to elements', () => {
+      // });
+    });
+
+    describe(`Test valid ${Package.name} objects`, () => {
+      const package1 = {
+        type: 'Package',
+        id: 'package1'
+      };
+      const package2 = {
+        type: 'Package',
+        id: 'package2',
+        name: 'package2',
+        description: 'package2',
+        propertyAssignments: null,
+        contents: null
+      };
+      const package3 = {
+        type: 'Package',
+        id: 'package3',
+        name: { en: 'package3' },
+        description: { en: 'package3' },
+        propertyAssignments: { someTag: true },
+        contents: []
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Package']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Package'));
+      it('Minimal packages should be valid', () => {
+        expect(serializationUtils.validate(package1)).toBe(true);
+        expect(serializationUtils.validate(package2)).toBe(true);
+        expect(serializationUtils.validate(package3)).toBe(true);
+      });
+      it("Minimal packages should not throw a }n exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(package1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(package2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(package3))).not.toThrow();
+      });
+      // it('Minimal packages should throw an exception due to broken references to elements', () => {
+      // });
+    });
+
+    describe(`Test valid ${Property.name} objects`, () => {
+      const propertyTypeReference = {
+        type: 'Class',
+        id: 'propertyType'
+      };
+
+      const property1 = {
+        type: 'Property',
+        id: 'property1'
+      };
+      const property2 = {
+        type: 'Property',
+        id: 'property2',
+        name: 'property2',
+        description: 'property2',
+        propertyAssignments: null,
+        stereotype: null,
+        aggregationKind: null,
+        cardinality: null,
+        isDerived: null,
+        isOrdered: null,
+        isReadOnly: null,
+        propertyType: null,
+        redefinedProperties: null,
+        subsettedProperties: null
+      };
+      const property3 = {
+        type: 'Property',
+        id: 'property3',
+        name: { en: 'property3' },
+        description: { en: 'property3' },
+        propertyAssignments: { someTag: true },
+        stereotype: 'begin',
+        aggregationKind: 'SHARED',
+        cardinality: '1..*',
+        isDerived: false,
+        isOrdered: true,
+        isReadOnly: false,
+        propertyType: propertyTypeReference,
+        redefinedProperties: [],
+        subsettedProperties: []
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Property']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Property'));
+      it('Minimal properties should be valid', () => {
+        expect(serializationUtils.validate(property1)).toBe(true);
+        expect(serializationUtils.validate(property2)).toBe(true);
+        expect(serializationUtils.validate(property3)).toBe(true);
+      });
+      it("Minimal properties should not throw a }n exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(property1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(property2))).not.toThrow();
+      });
+      it('Minimal properties should throw an exception due to broken references to elements', () => {
+        expect(() => serializationUtils.parse(JSON.stringify(property3))).toThrow();
+      });
+    });
+
+    describe(`Test valid ${Relation.name} objects`, () => {
+      const relation1 = {
+        type: 'Relation',
+        id: 'relation1'
+      };
+      const relation2 = {
+        type: 'Relation',
+        id: 'relation2',
+        name: 'relation2',
+        description: 'relation2',
+        propertyAssignments: null,
+        stereotype: null,
+        isAbstract: null,
+        isDerived: null,
+        properties: null
+      };
+      const relation3 = {
+        type: 'Relation',
+        id: 'relation3',
+        name: { en: 'relation3' },
+        description: { en: 'relation3' },
+        propertyAssignments: { someTag: true },
+        stereotype: 'material',
+        isAbstract: false,
+        isDerived: false,
+        properties: []
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Relation']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Relation'));
+      it('Minimal relations should be valid', () => {
+        expect(serializationUtils.validate(relation1)).toBe(true);
+        expect(serializationUtils.validate(relation2)).toBe(true);
+        expect(serializationUtils.validate(relation3)).toBe(true);
+      });
+      it("Minimal relations should not throw a }n exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(relation1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(relation2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(relation3))).not.toThrow();
+      });
+      // it('Minimal relations should throw an exception due to broken references to elements', () => {
+      // });
+    });
+
+    describe(`Test valid ${Project.name} objects`, () => {
+      const project1 = {
+        type: 'Project',
+        id: 'project1'
+      };
+      const project2 = {
+        type: 'Project',
+        id: 'project2',
+        name: 'project2',
+        description: 'project2',
+        model: null,
+        diagrams: null
+      };
+      const project3 = {
+        type: 'Project',
+        id: 'project3',
+        name: { en: 'project3' },
+        description: { en: 'project3' },
+        model: null,
+        diagrams: []
+      };
+
+      it(`Should retrieve correct schema id from 'OntoumlType'`, () =>
+        expect(serializationUtils.typeToSchemaId['Project']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/Project'));
+      it('Minimal projects should be valid', () => {
+        expect(serializationUtils.validate(project1)).toBe(true);
+        expect(serializationUtils.validate(project2)).toBe(true);
+        expect(serializationUtils.validate(project3)).toBe(true);
+      });
+      it("Minimal projects should not throw a }n exception as they don't have broken references to elements", () => {
+        expect(() => serializationUtils.parse(JSON.stringify(project1))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(project2))).not.toThrow();
+        expect(() => serializationUtils.parse(JSON.stringify(project3))).not.toThrow();
+      });
+      // it('Minimal projects should throw an exception due to broken references to elements', () => {
+      // });
     });
   });
 });

--- a/__tests__/libs/ontouml/schema.test.ts
+++ b/__tests__/libs/ontouml/schema.test.ts
@@ -1,0 +1,182 @@
+import {
+  Class,
+  Generalization,
+  GeneralizationSet,
+  Package,
+  Project,
+  Property,
+  serializationUtils,
+  Literal,
+  Relation,
+  Diagram,
+  ClassView,
+  RelationView,
+  GeneralizationView,
+  GeneralizationSetView,
+  PackageView,
+  Rectangle,
+  Text,
+  Path,
+  OntoumlElement
+} from '@libs/ontouml';
+
+describe('Schema tests', () => {
+  describe(`Test valid serializations of '${OntoumlElement.name}' objects against JSON Schema, but parsing fails where references cannot be resolved.`, () => {
+    it(`Test valid ${ClassView.name} objects.`, () => {
+      const classReference = {
+        type: 'Class',
+        id: 'modelElement'
+      };
+      const classView1 = {
+        type: 'ClassView',
+        id: 'classView1',
+        modelElement: classReference
+      };
+      const classView2 = {
+        type: 'ClassView',
+        id: 'classView2',
+        name: 'classView2',
+        description: 'classView2',
+        shape: {
+          type: 'Rectangle',
+          id: 'classView2_shape'
+        },
+        modelElement: classReference
+      };
+      const classView3 = {
+        type: 'ClassView',
+        id: 'classView3',
+        name: {
+          en: 'classView3'
+        },
+        description: {
+          en: 'classView3'
+        },
+        shape: {
+          type: 'Rectangle',
+          id: 'classView3_shape'
+        },
+        modelElement: classReference
+      };
+
+      expect(serializationUtils.typeToSchemaId['ClassView']).toBe('https://ontouml.org/ontouml-schema/2021-02-26/ClassView');
+      expect(serializationUtils.validate(classView1)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(classView1))).toThrow();
+      expect(serializationUtils.validate(classView2)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(classView2))).toThrow();
+      expect(serializationUtils.validate(classView3)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(classView3))).toThrow();
+    });
+
+    it(`Test valid ${GeneralizationSetView.name} objects`, () => {
+      const gsReference = {
+        type: 'GeneralizationSet',
+        id: 'modelElement'
+      };
+      const gsView1 = {
+        type: 'GeneralizationSetView',
+        id: 'gsView1',
+        modelElement: gsReference
+      };
+      const gsView2 = {
+        type: 'GeneralizationSetView',
+        id: 'gsView2',
+        name: 'gsView2',
+        description: 'gsView2',
+        shape: {
+          type: 'Text',
+          id: 'gsView2_shape'
+        },
+        modelElement: gsReference
+      };
+      const gsView3 = {
+        type: 'GeneralizationSetView',
+        id: 'gsView3',
+        name: {
+          en: 'gsView3'
+        },
+        description: {
+          en: 'gsView3'
+        },
+        shape: {
+          type: 'Text',
+          id: 'gsView3_shape'
+        },
+        modelElement: gsReference
+      };
+
+      expect(serializationUtils.typeToSchemaId['GeneralizationSetView']).toBe(
+        'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationSetView'
+      );
+      expect(serializationUtils.validate(gsView1)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(gsView1))).toThrow();
+      expect(serializationUtils.validate(gsView2)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(gsView2))).toThrow();
+      expect(serializationUtils.validate(gsView3)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(gsView3))).toThrow();
+    });
+
+    it(`Test valid ${GeneralizationView.name} objects`, () => {
+      const genReference = {
+        type: 'Generalization',
+        id: 'genReference'
+      };
+      const sourceReference = {
+        type: 'ClassView',
+        id: 'sourceReference'
+      };
+      const targetReference = {
+        type: 'ClassView',
+        id: 'targetReference'
+      };
+
+      const genView1 = {
+        type: 'GeneralizationView',
+        id: 'genView1',
+        modelElement: genReference,
+        source: sourceReference,
+        target: targetReference
+      };
+      const genView2 = {
+        type: 'GeneralizationView',
+        id: 'genView2',
+        name: 'genView2',
+        description: 'genView2',
+        shape: {
+          type: 'Path',
+          id: 'genView2_shape'
+        },
+        modelElement: genReference,
+        source: sourceReference,
+        target: targetReference
+      };
+      const genView3 = {
+        type: 'GeneralizationView',
+        id: 'genView3',
+        name: {
+          en: 'genView3'
+        },
+        description: {
+          en: 'genView3'
+        },
+        shape: {
+          type: 'Path',
+          id: 'genView3_shape'
+        },
+        modelElement: genReference,
+        source: sourceReference,
+        target: targetReference
+      };
+
+      expect(serializationUtils.typeToSchemaId['GeneralizationView']).toBe(
+        'https://ontouml.org/ontouml-schema/2021-02-26/GeneralizationView'
+      );
+      expect(serializationUtils.validate(genView1)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(genView1))).toThrow();
+      expect(serializationUtils.validate(genView2)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(genView2))).toThrow();
+      expect(serializationUtils.validate(genView3)).toBe(true);
+      expect(() => serializationUtils.parse(JSON.stringify(genView3))).toThrow();
+    });
+  });
+});

--- a/__tests__/libs/ontouml/serialization.test.ts
+++ b/__tests__/libs/ontouml/serialization.test.ts
@@ -88,6 +88,7 @@ describe('Serialization tests', () => {
     });
     it(`Validate basic ${Literal.name}`, () => expect(serializationUtils.validate(new Literal())).toBe(true));
     it(`Validate basic ${Diagram.name}`, () => expect(serializationUtils.validate(new Diagram())).toBe(true));
+
     it(`Validate basic ${ClassView.name}`, () => {
       const classView = new ClassView();
       classView.modelElement = new Class();
@@ -151,10 +152,10 @@ describe('Serialization tests', () => {
     });
 
     it(`Test ${Generalization.name} de-serialization`, () => {
-      const pkg = new Package();
-      const agent = new Class();
-      const person = new Class();
-      const gen = new Generalization({ general: agent, specific: person });
+      const pkg = new Package({ id: 'pkg_id' });
+      const agent = new Class({ id: 'agent_id' });
+      const person = new Class({ id: 'person_id' });
+      const gen = new Generalization({ id: 'gen_id', general: agent, specific: person });
 
       pkg.contents = [agent, person, gen];
 

--- a/__tests__/libs/ontouml/stereotypes.test.ts
+++ b/__tests__/libs/ontouml/stereotypes.test.ts
@@ -1,0 +1,251 @@
+import { ClassStereotype, PropertyStereotype, RelationStereotype, stereotypeUtils } from '@libs/ontouml';
+
+describe(`Test stereotype handling utility`, () => {
+  describe('Test class stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.ClassStereotypes).toHaveLength(21));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.TYPE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE_MIXIN);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.EVENT);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.SITUATION);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.CATEGORY);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.MIXIN);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.ROLE_MIXIN);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.PHASE_MIXIN);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.QUANTITY);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.MODE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.SUBKIND);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.ROLE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.PHASE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.ENUMERATION);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.DATATYPE);
+      expect(stereotypeUtils.ClassStereotypes).toContain(ClassStereotype.ABSTRACT);
+    });
+  });
+
+  describe('Test abstract class stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.AbstractStereotypes).toHaveLength(3));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.AbstractStereotypes).toContain(ClassStereotype.ENUMERATION);
+      expect(stereotypeUtils.AbstractStereotypes).toContain(ClassStereotype.DATATYPE);
+      expect(stereotypeUtils.AbstractStereotypes).toContain(ClassStereotype.ABSTRACT);
+    });
+  });
+
+  describe('Test endurant stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.EndurantStereotypes).toHaveLength(15));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE_MIXIN);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.CATEGORY);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.MIXIN);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.ROLE_MIXIN);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.PHASE_MIXIN);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.QUANTITY);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.MODE);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.SUBKIND);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.ROLE);
+      expect(stereotypeUtils.EndurantStereotypes).toContain(ClassStereotype.PHASE);
+    });
+  });
+
+  describe('Test class stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.SubstantialOnlyStereotypes).toHaveLength(3));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.SubstantialOnlyStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.SubstantialOnlyStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.SubstantialOnlyStereotypes).toContain(ClassStereotype.QUANTITY);
+    });
+  });
+
+  describe('Test moment-only stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.MomentOnlyStereotypes).toHaveLength(3));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.MomentOnlyStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.MomentOnlyStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.MomentOnlyStereotypes).toContain(ClassStereotype.MODE);
+    });
+  });
+
+  describe('Test non-sortal stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.NonSortalStereotypes).toHaveLength(5));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.NonSortalStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE_MIXIN);
+      expect(stereotypeUtils.NonSortalStereotypes).toContain(ClassStereotype.CATEGORY);
+      expect(stereotypeUtils.NonSortalStereotypes).toContain(ClassStereotype.MIXIN);
+      expect(stereotypeUtils.NonSortalStereotypes).toContain(ClassStereotype.ROLE_MIXIN);
+      expect(stereotypeUtils.NonSortalStereotypes).toContain(ClassStereotype.PHASE_MIXIN);
+    });
+  });
+
+  describe('Test sortal stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.SortalStereotypes).toHaveLength(10));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.QUANTITY);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.MODE);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.SUBKIND);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.ROLE);
+      expect(stereotypeUtils.SortalStereotypes).toContain(ClassStereotype.PHASE);
+    });
+  });
+
+  describe('Test ultimate sortal stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.UltimateSortalStereotypes).toHaveLength(6));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.QUANTITY);
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.UltimateSortalStereotypes).toContain(ClassStereotype.MODE);
+    });
+  });
+
+  describe('Test base sortal stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.BaseSortalStereotypes).toHaveLength(4));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.BaseSortalStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE);
+      expect(stereotypeUtils.BaseSortalStereotypes).toContain(ClassStereotype.SUBKIND);
+      expect(stereotypeUtils.BaseSortalStereotypes).toContain(ClassStereotype.ROLE);
+      expect(stereotypeUtils.BaseSortalStereotypes).toContain(ClassStereotype.PHASE);
+    });
+  });
+
+  describe('Test rigid stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.RigidStereotypes).toHaveLength(8));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.CATEGORY);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.KIND);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.COLLECTIVE);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.QUANTITY);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.RELATOR);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.QUALITY);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.MODE);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.SUBKIND);
+    });
+  });
+
+  describe('Test anti-rigid stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.AntiRigidStereotypes).toHaveLength(6));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE);
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.HISTORICAL_ROLE_MIXIN);
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.ROLE_MIXIN);
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.PHASE_MIXIN);
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.ROLE);
+      expect(stereotypeUtils.AntiRigidStereotypes).toContain(ClassStereotype.PHASE);
+    });
+  });
+
+  describe('Test semi-rigid stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.SemiRigidStereotypes).toHaveLength(1));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.SemiRigidStereotypes).toContain(ClassStereotype.MIXIN);
+    });
+  });
+
+  describe('Test relation stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.RelationStereotypes).toHaveLength(19));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.MATERIAL);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.DERIVATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.COMPARATIVE);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.MEDIATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.CHARACTERIZATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.EXTERNAL_DEPENDENCE);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.COMPONENT_OF);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.MEMBER_OF);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.SUBCOLLECTION_OF);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.SUBQUANTITY_OF);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.INSTANTIATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.TERMINATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.PARTICIPATIONAL);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.PARTICIPATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.HISTORICAL_DEPENDENCE);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.CREATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.MANIFESTATION);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.BRINGS_ABOUT);
+      expect(stereotypeUtils.RelationStereotypes).toContain(RelationStereotype.TRIGGERS);
+    });
+  });
+
+  describe('Test existential dependency stereotypes array', () => {
+    it('There should be a know number of stereotypes', () =>
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toHaveLength(11));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.BRINGS_ABOUT);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.CHARACTERIZATION);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.CREATION);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.MANIFESTATION);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.PARTICIPATION);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.PARTICIPATIONAL);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.TERMINATION);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.TRIGGERS);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.EXTERNAL_DEPENDENCE);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.HISTORICAL_DEPENDENCE);
+      expect(stereotypeUtils.ExistentialDependencyRelationStereotypes).toContain(RelationStereotype.MEDIATION);
+    });
+  });
+
+  describe('Test "existential dependent source" stereotypes array', () => {
+    it('There should be a know number of stereotypes', () =>
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toHaveLength(7));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.BRINGS_ABOUT);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.CREATION);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.MANIFESTATION);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.PARTICIPATION);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.PARTICIPATIONAL);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.TERMINATION);
+      expect(stereotypeUtils.ExistentialDependentSourceRelationStereotypes).toContain(RelationStereotype.TRIGGERS);
+    });
+  });
+
+  describe('Test "existential dependent target" stereotypes array', () => {
+    it('There should be a know number of stereotypes', () =>
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toHaveLength(7));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.BRINGS_ABOUT);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.CHARACTERIZATION);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.CREATION);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.EXTERNAL_DEPENDENCE);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.HISTORICAL_DEPENDENCE);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.MEDIATION);
+      expect(stereotypeUtils.ExistentialDependentTargetRelationStereotypes).toContain(RelationStereotype.PARTICIPATIONAL);
+    });
+  });
+
+  describe('Test part-whole stereotypes array', () => {
+    it('There should be a know number of stereotypes', () =>
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toHaveLength(5));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toContain(RelationStereotype.COMPONENT_OF);
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toContain(RelationStereotype.MEMBER_OF);
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toContain(RelationStereotype.SUBCOLLECTION_OF);
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toContain(RelationStereotype.SUBQUANTITY_OF);
+      expect(stereotypeUtils.PartWholeRelationStereotypes).toContain(RelationStereotype.PARTICIPATIONAL);
+    });
+  });
+
+  describe('Test property stereotypes array', () => {
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.PropertyStereotypes).toHaveLength(2));
+    it('Each of these must be a in the array', () => {
+      expect(stereotypeUtils.PropertyStereotypes).toContain(PropertyStereotype.BEGIN);
+      expect(stereotypeUtils.PropertyStereotypes).toContain(PropertyStereotype.END);
+    });
+  });
+});

--- a/__tests__/libs/ontouml/stereotypes.test.ts
+++ b/__tests__/libs/ontouml/stereotypes.test.ts
@@ -126,7 +126,7 @@ describe(`Test stereotype handling utility`, () => {
   });
 
   describe('Test rigid stereotypes array', () => {
-    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.RigidStereotypes).toHaveLength(8));
+    it('There should be a know number of stereotypes', () => expect(stereotypeUtils.RigidStereotypes).toHaveLength(14));
     it('Each of these must be a in the array', () => {
       expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.CATEGORY);
       expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.KIND);
@@ -136,6 +136,12 @@ describe(`Test stereotype handling utility`, () => {
       expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.QUALITY);
       expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.MODE);
       expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.SUBKIND);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.EVENT);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.SITUATION);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.TYPE);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.ABSTRACT);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.DATATYPE);
+      expect(stereotypeUtils.RigidStereotypes).toContain(ClassStereotype.ENUMERATION);
     });
   });
 

--- a/__tests__/libs/verification/class_verification.test.ts
+++ b/__tests__/libs/verification/class_verification.test.ts
@@ -3,19 +3,22 @@ import { ClassVerification, VerificationIssueCode } from '@libs/verification';
 
 describe(`${ClassVerification.name} tests`, () => {
   describe(`Test ClassVerification.${ClassVerification.verifyClass.name}`, () => {
-    it(`Class verification stops when minimal check raises issues`, () => {
+    it(`Class verification stops when minimal check raises issues, but continues additional verification otherwise.`, () => {
       const stereotypelessClass = new Class();
-      let issues = ClassVerification.verifyClass(stereotypelessClass);
+      const issuesOfStereotypeless = ClassVerification.verifyClass(stereotypelessClass);
 
-      expect(issues).toHaveLength(1);
-      expect(issues[0]).toMatchObject({ code: VerificationIssueCode.class_not_unique_stereotype });
+      expect(issuesOfStereotypeless).toHaveLength(1);
+      expect(issuesOfStereotypeless[0]).toMatchObject({ code: VerificationIssueCode.class_not_unique_stereotype });
 
       const model = new Package();
       const agent = model.createSubkind();
-      issues = ClassVerification.verifyClass(agent);
+      const agentType = model.createType();
+      const issuesOfAgent = ClassVerification.verifyClass(agent);
+      const issuesOfAgentType = ClassVerification.verifyClass(agentType);
 
-      expect(issues).toHaveLength(1);
-      expect(issues[0]).toMatchObject({ code: VerificationIssueCode.class_missing_identity_provider });
+      expect(issuesOfAgent).toHaveLength(1);
+      expect(issuesOfAgent[0]).toMatchObject({ code: VerificationIssueCode.class_missing_identity_provider });
+      expect(issuesOfAgentType).toHaveLength(0);
     });
   });
 

--- a/resources/schemas/class.schema.json
+++ b/resources/schemas/class.schema.json
@@ -72,9 +72,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableString"
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "type",
-    "id"
-  ]
+  "additionalProperties": true,
+  "required": ["type", "id"]
 }

--- a/resources/schemas/class.schema.json
+++ b/resources/schemas/class.schema.json
@@ -35,7 +35,6 @@
       "oneOf": [
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/Literal"
           }
@@ -54,10 +53,8 @@
         {
           "type": "array",
           "uniqueItems": true,
-          "minItems": 1,
           "items": {
-            "type": "string",
-            "minLength": 1
+            "type": "string"
           }
         }
       ]

--- a/resources/schemas/class.schema.json
+++ b/resources/schemas/class.schema.json
@@ -75,18 +75,6 @@
   "additionalProperties": false,
   "required": [
     "type",
-    "id",
-    "name",
-    "description",
-    "propertyAssignments",
-    "stereotype",
-    "isAbstract",
-    "isDerived",
-    "properties",
-    "literals",
-    "restrictedTo",
-    "isExtensional",
-    "isPowertype",
-    "order"
+    "id"
   ]
 }

--- a/resources/schemas/class_view.schema.json
+++ b/resources/schemas/class_view.schema.json
@@ -23,5 +23,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "modelElement", "shape"]
+  "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/class_view.schema.json
+++ b/resources/schemas/class_view.schema.json
@@ -22,6 +22,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/RectangleShape"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/definitions.schema.json
+++ b/resources/schemas/definitions.schema.json
@@ -23,24 +23,36 @@
       "type": "integer",
       "minimum": 0
     },
-    "nullableString": {
-      "$id": "#nullableString",
-      "description": "A auxiliary definition for nullable string fields.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "nullableBoolean": {
       "$id": "#nullableBoolean",
       "description": "A auxiliary definition for nullable boolean fields.",
       "oneOf": [
         {
           "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nullableNatural": {
+      "$id": "#nullableNatural",
+      "description": "A auxiliary definition for nullable natural number fields.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/natural"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nullableString": {
+      "$id": "#nullableString",
+      "description": "A auxiliary definition for nullable string fields.",
+      "oneOf": [
+        {
+          "type": "string"
         },
         {
           "type": "null"

--- a/resources/schemas/definitions.schema.json
+++ b/resources/schemas/definitions.schema.json
@@ -28,8 +28,7 @@
       "description": "A auxiliary definition for nullable string fields.",
       "oneOf": [
         {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         {
           "type": "null"
@@ -78,7 +77,6 @@
       "oneOf": [
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/Property"
           }
@@ -92,6 +90,9 @@
       "$id": "#propertyAssignments",
       "description": "An object that contains assignments to properties instantiated by the container object. Each field in this object corresponds to an assigment, whose possible values are restricted to null, boolean, number, string, reference, or an array containing any of the former. Assignments are analogous to UML's notion of tagged values. Nullable.",
       "oneOf": [
+        {
+          "type": "null"
+        },
         {
           "type": "object",
           "additionalProperties": {
@@ -114,7 +115,6 @@
               {
                 "type": "array",
                 "uniqueItems": true,
-                "minItems": 1,
                 "items": {
                   "anyOf": [
                     {
@@ -134,9 +134,6 @@
               }
             ]
           }
-        },
-        {
-          "type": "null"
         }
       ]
     },
@@ -165,13 +162,9 @@
     "stereotype": {
       "$id": "#stereotype",
       "description": "A nullable string containing the stereotype applied to its container object. If no stereotype is applied to the object, the value of this field must be null.",
-      "oneOf": [
+      "allOf": [
         {
-          "type": "string",
-          "minLength": 1
-        },
-        {
-          "type": "null"
+          "$ref": "#/definitions/nullableString"
         }
       ]
     },
@@ -180,18 +173,12 @@
       "description": "A nullable field that may contain either a text string or a non-empty object where each key must indicate a language code conforming to the BCP 47 recommendations.",
       "oneOf": [
         {
-          "type": "null"
-        },
-        {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/nullableString"
         },
         {
           "type": "object",
-          "minProperties": 1,
           "additionalProperties": {
-            "type": "string",
-            "minLength": 1
+            "$ref": "#/definitions/nullableString"
           }
         }
       ]

--- a/resources/schemas/diagram.schema.json
+++ b/resources/schemas/diagram.schema.json
@@ -48,9 +48,6 @@
     "owner": {
       "oneOf": [
         {
-          "type": "null"
-        },
-        {
           "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
         }
       ]

--- a/resources/schemas/diagram.schema.json
+++ b/resources/schemas/diagram.schema.json
@@ -53,6 +53,6 @@
       ]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/diagram.schema.json
+++ b/resources/schemas/diagram.schema.json
@@ -46,9 +46,16 @@
       ]
     },
     "owner": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
+        }
+      ]
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "contents", "owner"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/diagram.schema.json
+++ b/resources/schemas/diagram.schema.json
@@ -23,7 +23,6 @@
         },
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "oneOf": [
               {

--- a/resources/schemas/generalization.schema.json
+++ b/resources/schemas/generalization.schema.json
@@ -26,6 +26,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "general", "specific"]
 }

--- a/resources/schemas/generalization.schema.json
+++ b/resources/schemas/generalization.schema.json
@@ -27,5 +27,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "propertyAssignments", "general", "specific"]
+  "required": ["type", "id", "general", "specific"]
 }

--- a/resources/schemas/generalization_set.schema.json
+++ b/resources/schemas/generalization_set.schema.json
@@ -32,7 +32,6 @@
       "oneOf": [
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
           }

--- a/resources/schemas/generalization_set.schema.json
+++ b/resources/schemas/generalization_set.schema.json
@@ -42,9 +42,6 @@
       ]
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "type",
-    "id"
-  ]
+  "additionalProperties": true,
+  "required": ["type", "id"]
 }

--- a/resources/schemas/generalization_set.schema.json
+++ b/resources/schemas/generalization_set.schema.json
@@ -45,13 +45,6 @@
   "additionalProperties": false,
   "required": [
     "type",
-    "id",
-    "name",
-    "description",
-    "propertyAssignments",
-    "isDisjoint",
-    "isComplete",
-    "categorizer",
-    "generalizations"
+    "id"
   ]
 }

--- a/resources/schemas/generalization_set_view.schema.json
+++ b/resources/schemas/generalization_set_view.schema.json
@@ -23,5 +23,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "modelElement", "shape"]
+  "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/generalization_set_view.schema.json
+++ b/resources/schemas/generalization_set_view.schema.json
@@ -22,6 +22,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/TextShape"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/generalization_view.schema.json
+++ b/resources/schemas/generalization_view.schema.json
@@ -29,5 +29,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "modelElement", "source", "target", "shape"]
+  "required": ["type", "id", "modelElement", "source", "target"]
 }

--- a/resources/schemas/generalization_view.schema.json
+++ b/resources/schemas/generalization_view.schema.json
@@ -28,6 +28,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/PathShape"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "modelElement", "source", "target"]
 }

--- a/resources/schemas/literal.schema.json
+++ b/resources/schemas/literal.schema.json
@@ -21,5 +21,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "propertyAssignments"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/literal.schema.json
+++ b/resources/schemas/literal.schema.json
@@ -20,6 +20,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#propertyAssignments"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/package.schema.json
+++ b/resources/schemas/package.schema.json
@@ -26,7 +26,6 @@
         },
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "oneOf": [
               {

--- a/resources/schemas/package.schema.json
+++ b/resources/schemas/package.schema.json
@@ -50,5 +50,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "contents", "propertyAssignments"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/package.schema.json
+++ b/resources/schemas/package.schema.json
@@ -49,6 +49,6 @@
       ]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/package_view.schema.json
+++ b/resources/schemas/package_view.schema.json
@@ -23,5 +23,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "modelElement", "shape"]
+  "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/package_view.schema.json
+++ b/resources/schemas/package_view.schema.json
@@ -22,6 +22,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/RectangleShape"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "modelElement"]
 }

--- a/resources/schemas/path_shape.schema.json
+++ b/resources/schemas/path_shape.schema.json
@@ -22,7 +22,6 @@
         },
         {
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "object",
             "properties": {

--- a/resources/schemas/path_shape.schema.json
+++ b/resources/schemas/path_shape.schema.json
@@ -40,5 +40,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "points"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/path_shape.schema.json
+++ b/resources/schemas/path_shape.schema.json
@@ -26,19 +26,19 @@
             "type": "object",
             "properties": {
               "x": {
-                "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+                "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
               },
               "y": {
-                "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+                "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
               }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["x", "y"]
           }
         }
       ]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/project.schema.json
+++ b/resources/schemas/project.schema.json
@@ -38,6 +38,6 @@
       ]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/project.schema.json
+++ b/resources/schemas/project.schema.json
@@ -39,5 +39,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "model", "diagrams"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/property.schema.json
+++ b/resources/schemas/property.schema.json
@@ -78,20 +78,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "type",
-    "id",
-    "name",
-    "description",
-    "cardinality",
-    "stereotype",
-    "propertyAssignments",
-    "propertyType",
-    "subsettedProperties",
-    "redefinedProperties",
-    "aggregationKind",
-    "isDerived",
-    "isOrdered",
-    "isReadOnly"
-  ]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/property.schema.json
+++ b/resources/schemas/property.schema.json
@@ -52,7 +52,6 @@
       "oneOf": [
         {
           "type": "array",
-          "minItems": 1,
           "uniqueItems": true,
           "items": {
             "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"
@@ -67,7 +66,6 @@
       "oneOf": [
         {
           "type": "array",
-          "minItems": 1,
           "uniqueItems": true,
           "items": {
             "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#reference"

--- a/resources/schemas/property.schema.json
+++ b/resources/schemas/property.schema.json
@@ -77,6 +77,6 @@
       ]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/rectangle_shape.schema.json
+++ b/resources/schemas/rectangle_shape.schema.json
@@ -16,18 +16,18 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#text"
     },
     "x": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "y": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "width": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "height": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/rectangle_shape.schema.json
+++ b/resources/schemas/rectangle_shape.schema.json
@@ -29,5 +29,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "x", "y", "width", "height"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/relation.schema.json
+++ b/resources/schemas/relation.schema.json
@@ -32,6 +32,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#properties"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/resources/schemas/relation.schema.json
+++ b/resources/schemas/relation.schema.json
@@ -33,5 +33,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "stereotype", "propertyAssignments", "isAbstract", "isDerived", "properties"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/relation_view.schema.json
+++ b/resources/schemas/relation_view.schema.json
@@ -29,5 +29,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "modelElement", "source", "target", "shape"]
+  "required": ["type", "id", "modelElement", "source", "target"]
 }

--- a/resources/schemas/relation_view.schema.json
+++ b/resources/schemas/relation_view.schema.json
@@ -28,6 +28,6 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/PathShape"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id", "modelElement", "source", "target"]
 }

--- a/resources/schemas/text_shape.schema.json
+++ b/resources/schemas/text_shape.schema.json
@@ -32,5 +32,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["type", "id", "name", "description", "x", "y", "width", "height", "value"]
+  "required": ["type", "id"]
 }

--- a/resources/schemas/text_shape.schema.json
+++ b/resources/schemas/text_shape.schema.json
@@ -16,21 +16,21 @@
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#text"
     },
     "x": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "y": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "width": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "height": {
-      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#natural"
+      "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableNatural"
     },
     "value": {
       "$ref": "https://ontouml.org/ontouml-schema/2021-02-26/definitions#nullableString"
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["type", "id"]
 }

--- a/src/libs/ontouml/model/generalization.ts
+++ b/src/libs/ontouml/model/generalization.ts
@@ -94,4 +94,18 @@ export class Generalization extends ModelElement {
 
     return generalizationSerialization;
   }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    super.resolveReferences(elementReferenceMap);
+
+    const { general, specific } = this;
+
+    if (general) {
+      this.general = OntoumlElement.resolveReference(general, elementReferenceMap, this, 'general');
+    }
+
+    if (specific) {
+      this.specific = OntoumlElement.resolveReference(specific, elementReferenceMap, this, 'specific');
+    }
+  }
 }

--- a/src/libs/ontouml/model/generalization_set.ts
+++ b/src/libs/ontouml/model/generalization_set.ts
@@ -176,4 +176,20 @@ export class GeneralizationSet extends ModelElement {
 
     return object;
   }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    super.resolveReferences(elementReferenceMap);
+
+    const { categorizer, generalizations } = this;
+
+    if (categorizer) {
+      this.categorizer = OntoumlElement.resolveReference(categorizer, elementReferenceMap, this, 'categorizer');
+    }
+
+    if (Array.isArray(generalizations)) {
+      this.generalizations = generalizations.map((generalization: Generalization) =>
+        OntoumlElement.resolveReference(generalization, elementReferenceMap, this, 'generalizations')
+      );
+    }
+  }
 }

--- a/src/libs/ontouml/model/model_element.ts
+++ b/src/libs/ontouml/model/model_element.ts
@@ -65,4 +65,8 @@ export abstract class ModelElement extends OntoumlElement {
       return null;
     }
   }
+
+  resolveReferences(_elementReferenceMap: Map<string, OntoumlElement>): void {
+    // TODO: resolve references within propertyAssignments
+  }
 }

--- a/src/libs/ontouml/model/natures.ts
+++ b/src/libs/ontouml/model/natures.ts
@@ -12,6 +12,20 @@ export enum OntologicalNature {
   abstract = 'abstract'
 }
 
+const Natures = [
+  OntologicalNature.functional_complex,
+  OntologicalNature.collective,
+  OntologicalNature.quantity,
+  OntologicalNature.intrinsic_mode,
+  OntologicalNature.extrinsic_mode,
+  OntologicalNature.quality,
+  OntologicalNature.relator,
+  OntologicalNature.event,
+  OntologicalNature.situation,
+  OntologicalNature.type,
+  OntologicalNature.abstract
+];
+
 const EndurantNatures = [
   OntologicalNature.functional_complex,
   OntologicalNature.collective,
@@ -35,10 +49,18 @@ const IntrinsicMomentNatures = [OntologicalNature.intrinsic_mode, OntologicalNat
 
 const ExtrinsicMomentNatures = [OntologicalNature.extrinsic_mode, OntologicalNature.relator];
 
-const naturesArrays = [EndurantNatures, SubstantialNatures, MomentNatures, IntrinsicMomentNatures, ExtrinsicMomentNatures];
+const naturesArrays = [
+  Natures,
+  EndurantNatures,
+  SubstantialNatures,
+  MomentNatures,
+  IntrinsicMomentNatures,
+  ExtrinsicMomentNatures
+];
 naturesArrays.forEach((array: OntologicalNature[]) => Object.freeze(array));
 
 export const natureUtils = {
+  Natures,
   EndurantNatures,
   SubstantialNatures,
   MomentNatures,

--- a/src/libs/ontouml/model/property.ts
+++ b/src/libs/ontouml/model/property.ts
@@ -144,4 +144,14 @@ export class Property extends Decoratable<PropertyStereotype> {
 
     return propertySerialization;
   }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    super.resolveReferences(elementReferenceMap);
+
+    const { propertyType } = this;
+
+    if (propertyType) {
+      this.propertyType = OntoumlElement.resolveReference(propertyType, elementReferenceMap, this, 'propertyType');
+    }
+  }
 }

--- a/src/libs/ontouml/model/stereotypes.ts
+++ b/src/libs/ontouml/model/stereotypes.ts
@@ -80,7 +80,7 @@ const BaseSortalStereotypes = [
 
 const SortalStereotypes = [...UltimateSortalStereotypes, ...BaseSortalStereotypes];
 
-// By rigid. anti-rigid, and semi-rigid stereotypes we only classify those presented as such in UFO (i.e., if you don't specialize the taxonomy you are out)
+// TODO: review if we should consider as rigid/anti-rigid/semi-rigid only those stereotypes whose respective types specialize Rigid/Anti-Rigid/Semi-Rigid in UFO. This introduces breaks to the gUFO transformation
 const RigidStereotypes = [
   ClassStereotype.KIND,
   ClassStereotype.QUANTITY,
@@ -89,7 +89,13 @@ const RigidStereotypes = [
   ClassStereotype.QUALITY,
   ClassStereotype.RELATOR,
   ClassStereotype.SUBKIND,
-  ClassStereotype.CATEGORY
+  ClassStereotype.CATEGORY,
+  ClassStereotype.EVENT,
+  ClassStereotype.SITUATION,
+  ClassStereotype.TYPE,
+  ClassStereotype.ABSTRACT,
+  ClassStereotype.DATATYPE,
+  ClassStereotype.ENUMERATION
 ];
 
 const AntiRigidStereotypes = [

--- a/src/libs/ontouml/model/stereotypes.ts
+++ b/src/libs/ontouml/model/stereotypes.ts
@@ -70,6 +70,7 @@ const UltimateSortalStereotypes = [
   ClassStereotype.MODE
 ];
 
+// TODO: consider renaming "base" to "lower"
 const BaseSortalStereotypes = [
   ClassStereotype.SUBKIND,
   ClassStereotype.PHASE,
@@ -79,6 +80,7 @@ const BaseSortalStereotypes = [
 
 const SortalStereotypes = [...UltimateSortalStereotypes, ...BaseSortalStereotypes];
 
+// By rigid. anti-rigid, and semi-rigid stereotypes we only classify those presented as such in UFO (i.e., if you don't specialize the taxonomy you are out)
 const RigidStereotypes = [
   ClassStereotype.KIND,
   ClassStereotype.QUANTITY,
@@ -87,13 +89,7 @@ const RigidStereotypes = [
   ClassStereotype.QUALITY,
   ClassStereotype.RELATOR,
   ClassStereotype.SUBKIND,
-  ClassStereotype.CATEGORY,
-  ClassStereotype.EVENT,
-  ClassStereotype.SITUATION,
-  ClassStereotype.TYPE,
-  ClassStereotype.ABSTRACT,
-  ClassStereotype.DATATYPE,
-  ClassStereotype.ENUMERATION
+  ClassStereotype.CATEGORY
 ];
 
 const AntiRigidStereotypes = [

--- a/src/libs/ontouml/model/stereotypes.ts
+++ b/src/libs/ontouml/model/stereotypes.ts
@@ -115,7 +115,13 @@ const EndurantStereotypes = [...SortalStereotypes, ...NonSortalStereotypes];
 
 const AbstractStereotypes = [ClassStereotype.ABSTRACT, ClassStereotype.DATATYPE, ClassStereotype.ENUMERATION];
 
-const ClassStereotypes = [...EndurantStereotypes, ...AbstractStereotypes, ClassStereotype.EVENT, ClassStereotype.SITUATION];
+const ClassStereotypes = [
+  ...EndurantStereotypes,
+  ...AbstractStereotypes,
+  ClassStereotype.EVENT,
+  ClassStereotype.SITUATION,
+  ClassStereotype.TYPE
+];
 
 const RelationStereotypes = [
   RelationStereotype.MATERIAL,

--- a/src/libs/ontouml/ontouml_element.ts
+++ b/src/libs/ontouml/ontouml_element.ts
@@ -121,4 +121,45 @@ export abstract class OntoumlElement {
 
     return object;
   }
+
+  /** Resolve fields containing references (i.e., not contents) replacing the
+   * object with the instance of `OntoumlElement` in `elementReferenceMap` with
+   * the same `id`. This method is NOT recursive.
+   *
+   * @throws throws an error when no entry in the `elementReferenceMap` has a
+   * matching `id`.
+   *
+   * @param elementReferenceMap id-based map of all instances of
+   * `OntoumlElement` in the same context or project. */
+  abstract resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void;
+
+  /** Support method the returns an instance of `OntoumlElement` from a element
+   * map based on the reference's id throwing an broken reference exception in
+   * case an element with matching id is not found in the map.
+   *
+   * @throws Error accusing broken reference if a element with matching id is
+   * not found in the map */
+  static resolveReference<T extends OntoumlElement>(
+    reference: T,
+    elementReferenceMap: Map<string, OntoumlElement>,
+    container?: OntoumlElement,
+    field?: string
+  ): T {
+    if (!reference) {
+      return reference;
+    }
+
+    const elementId = reference?.id;
+    const element = elementReferenceMap.get(elementId) as T;
+
+    if (element) {
+      return element;
+    } else {
+      const message =
+        container && field
+          ? `Could not resolve broken reference '${field}' in ${container.constructor.name} '${container.id}'.`
+          : `Could not resolve broken reference.`;
+      throw new Error(message);
+    }
+  }
 }

--- a/src/libs/ontouml/project.ts
+++ b/src/libs/ontouml/project.ts
@@ -345,4 +345,7 @@ export class Project extends OntoumlElement implements ModelElementContainer {
 
     return projectSerialization;
   }
+
+  // No reference fields to resolve/replace
+  resolveReferences(_elementReferenceMap: Map<string, OntoumlElement>): void {}
 }

--- a/src/libs/ontouml/serialization.ts
+++ b/src/libs/ontouml/serialization.ts
@@ -222,6 +222,7 @@ function parse(serializedElement: string, validateElement: boolean = false): Ont
     }
   }
 
+  // TODO: check reference type on parse
   return JSON.parse(serializedElement, revive);
 }
 

--- a/src/libs/ontouml/serialization.ts
+++ b/src/libs/ontouml/serialization.ts
@@ -22,6 +22,7 @@ import {
 } from '.';
 import Ajv from 'ajv';
 
+/** An object containing a map JSON Schema ids and their corresponding schemas. */
 const schemas = {
   'https://ontouml.org/ontouml-schema/2021-02-26/Project': require('@resources/schemas/project.schema.json'),
   'https://ontouml.org/ontouml-schema/2021-02-26/Package': require('@resources/schemas/package.schema.json'),
@@ -43,6 +44,8 @@ const schemas = {
   'https://ontouml.org/ontouml-schema/2021-02-26/definitions': require('@resources/schemas/definitions.schema.json')
 };
 
+/** An object containing a map between `OntoumlType` values and the ids of their
+ * corresponding JSON Schemas. */
 const typeToSchemaId = {
   [`${OntoumlType.PROJECT_TYPE}`]: 'https://ontouml.org/ontouml-schema/2021-02-26/Project',
   [`${OntoumlType.PACKAGE_TYPE}`]: 'https://ontouml.org/ontouml-schema/2021-02-26/Package',
@@ -68,45 +71,44 @@ const ajv = new Ajv({
   schemas: Object.values(schemas)
 });
 
+/** Function that validates an `OntoumlElement` object against its corresponding
+ * JSON Schema. */
 function validate(element: OntoumlElement): true | object | PromiseLike<any>;
+
+/** Function that validates an object against its corresponding JSON Schema
+ * based on the value of its `type` field. */
 function validate(serializedProject: object): true | object | PromiseLike<any>;
+
+/** Function that validates a string representing a serialized `OntoumlElement`
+ * object against its corresponding JSON Schema. */
 function validate(serializedProject: string): true | object | PromiseLike<any>;
+
 function validate(input: any): true | object | PromiseLike<any> {
   if (!input) {
     throw new Error('Unexpected parameter');
   }
-  
-  let schemaId = typeToSchemaId[OntoumlType.PROJECT_TYPE];
+
+  if (input instanceof OntoumlElement) {
+    // a normal OntoumlElement will always fail the schemas due to additional properties
+    input = JSON.stringify(input);
+  }
 
   if (typeof input === 'string') {
+    // the schemas only accept objects
     input = JSON.parse(input);
-  } else if (input instanceof OntoumlElement) {
-    schemaId = typeToSchemaId[input.type];
-    input = JSON.parse(JSON.stringify(input));
-  } else if (typeof input !== 'object') {
+  }
+
+  if (typeof input !== 'object') {
+    // if the input is not an object at this point, the input was invalid
     throw new Error('Unexpected parameter');
   }
 
-  let validator = ajv.getSchema(schemaId);
-  let isValid = validator(input);
+  // we'll always have a schema to check even in the absence of a valid `type` field
+  const schemaId = typeToSchemaId[input.type] || typeToSchemaId[OntoumlType.PROJECT_TYPE];
+  const validator = ajv.getSchema(schemaId);
+  const isValid = validator(input);
 
   return isValid ? isValid : validator.errors;
-}
-
-function isOntoumlElement(value: any): boolean {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  return typeof value.type === 'string' && typeof value.id === 'string' && Object.keys(value).length > 2;
-}
-
-function isReferenceObject(value: any): boolean {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  return typeof value.type === 'string' && typeof value.id === 'string' && Object.keys(value).length === 2;
 }
 
 function getElementMap(element: OntoumlElement): Map<string, OntoumlElement> {
@@ -117,39 +119,13 @@ function getElementMap(element: OntoumlElement): Map<string, OntoumlElement> {
   return map;
 }
 
-function resolveReferences(contentsMap: Map<string, OntoumlElement>, contents: OntoumlElement[]) {
-  for (const content of contents) {
-    for (const [key, value] of Object.entries(content)) {
-      if (isReferenceObject(value)) {
-        const referencedElement = contentsMap.get(value.id);
-
-        if (!referencedElement) {
-          throw new Error('Object contains broken references');
-        } else {
-          content[key] = referencedElement;
-        }
-      } else if (Array.isArray(value)) {
-        value.forEach((item, index) => {
-          // TODO: refactoring
-          if (isReferenceObject(item)) {
-            const referencedElement = contentsMap.get(item.id);
-
-            if (!referencedElement) {
-              throw new Error('Object contains broken references');
-            } else {
-              value[index] = referencedElement;
-            }
-          }
-        });
-      }
-    }
-  }
-}
-
+/** Function that receives an object represent an `OntoumlElement` and returns
+ * an instance of the corresponding class based on the value of its `type`
+ * field. */
 function clone(original: Partial<OntoumlElement>): OntoumlElement {
   switch (original.type) {
     case OntoumlType.PROJECT_TYPE:
-      return new Project(original as any);
+      return new Project(original);
     case OntoumlType.PACKAGE_TYPE:
       return new Package(original);
     case OntoumlType.CLASS_TYPE:
@@ -161,7 +137,7 @@ function clone(original: Partial<OntoumlElement>): OntoumlElement {
     case OntoumlType.GENERALIZATION_SET_TYPE:
       return new GeneralizationSet(original);
     case OntoumlType.PROPERTY_TYPE:
-      return new Property(original as any);
+      return new Property(original);
     case OntoumlType.LITERAL_TYPE:
       return new Literal(original);
     case OntoumlType.DIAGRAM:
@@ -187,10 +163,16 @@ function clone(original: Partial<OntoumlElement>): OntoumlElement {
   }
 }
 
+/** Parsing function to be passed as argument to `JSON.stringify` to support the
+ * de-serialization of `OntoumlElement` objects. */
 function revive(_key: any, value: any): any {
   let element: OntoumlElement;
 
-  if (isOntoumlElement(value)) {
+  /* It is not possible to distinguish a reference from an object with
+   * missing fields, so let's clone everything that has type and id and later
+   * resolve the references where only objects returned in getContents() are not
+   * references. */
+  if (value?.type && value?.id) {
     if (value?.type === OntoumlType.TEXT || value?.type === OntoumlType.RECTANGLE) {
       value.topLeft = {
         x: value.x,
@@ -201,24 +183,38 @@ function revive(_key: any, value: any): any {
     element = clone(value);
   }
 
-  if (element instanceof Project || (!_key && element instanceof ModelElement)) {
+  if (element instanceof Project || (!_key && element instanceof OntoumlElement)) {
     const project = element instanceof Project ? (element as Project) : null;
     const allContents: OntoumlElement[] = element.getAllContents();
 
+    // Set references to container and project
     allContents.forEach((content: ModelElement) => {
       content.project = project;
       content.getContents().forEach((ownContent: ModelElement) => (ownContent.container = content));
     });
 
     const contentsMap = getElementMap(element as ModelElement);
-    resolveReferences(contentsMap, [element, ...allContents]);
+    const allElements = [element, ...allContents];
+
+    // Resolves reference fields replacing objects that are created to
+    // temporarily hold a type and an id
+    allElements.forEach((content: ModelElement) => content.resolveReferences(contentsMap));
   }
 
   return element ? element : value;
 }
 
-function parse(serializedElement: string, validateProject: boolean = false): OntoumlElement {
-  if (validateProject) {
+/** Parse function that receives a `OntoumlElement` serialized into a string and
+ * returns an object instance of `OntoumlElement`. The function also tries to
+ * resolve references to other elements if present and an exception is thrown
+ * in case of failure.
+ *
+ * @param serializedElement - the string to be parsed
+ * @param validateElement - an optional boolean identifying whether the
+ * `serializedElement` should be validate against the corresponding JSON Schema.
+ * Default `false`.  */
+function parse(serializedElement: string, validateElement: boolean = false): OntoumlElement {
+  if (validateElement) {
     const result = validate(serializedElement);
 
     if (result !== true) {
@@ -229,8 +225,12 @@ function parse(serializedElement: string, validateProject: boolean = false): Ont
   return JSON.parse(serializedElement, revive);
 }
 
+/** A utility module designed to support the de-serialization and validation of
+ * `OntoumlElement` objects. */
 export const serializationUtils = {
   validate,
   revive,
-  parse
+  parse,
+  schemas,
+  typeToSchemaId
 };

--- a/src/libs/ontouml/view/connector_view.ts
+++ b/src/libs/ontouml/view/connector_view.ts
@@ -1,4 +1,5 @@
 import { ModelElement, ElementView, Path } from '..';
+import { OntoumlElement } from '../ontouml_element';
 
 export abstract class ConnectorView<T extends ModelElement> extends ElementView<T, Path> {
   source: ElementView<any, any>;
@@ -27,5 +28,19 @@ export abstract class ConnectorView<T extends ModelElement> extends ElementView<
     serialization.target = this.target?.getReference();
 
     return serialization;
+  }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    super.resolveReferences(elementReferenceMap);
+
+    const { source, target } = this;
+
+    if (source) {
+      this.source = OntoumlElement.resolveReference(source, elementReferenceMap, this, 'source');
+    }
+
+    if (target) {
+      this.target = OntoumlElement.resolveReference(target, elementReferenceMap, this, 'target');
+    }
   }
 }

--- a/src/libs/ontouml/view/diagram.ts
+++ b/src/libs/ontouml/view/diagram.ts
@@ -155,4 +155,12 @@ export class Diagram extends OntoumlElement {
 
     return serialization;
   }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    const { owner } = this;
+
+    if (owner) {
+      this.owner = OntoumlElement.resolveReference(owner, elementReferenceMap, this, 'owner');
+    }
+  }
 }

--- a/src/libs/ontouml/view/element_view.ts
+++ b/src/libs/ontouml/view/element_view.ts
@@ -31,4 +31,12 @@ export abstract class ElementView<T extends ModelElement, S extends Shape> exten
 
     return serialization;
   }
+
+  resolveReferences(elementReferenceMap: Map<string, OntoumlElement>): void {
+    const { modelElement } = this;
+
+    if (modelElement) {
+      this.modelElement = OntoumlElement.resolveReference(modelElement, elementReferenceMap, this, 'modelElement');
+    }
+  }
 }

--- a/src/libs/ontouml/view/shape.ts
+++ b/src/libs/ontouml/view/shape.ts
@@ -1,7 +1,11 @@
 import { DiagramElement } from '..';
+import { OntoumlElement } from '../ontouml_element';
 
 export abstract class Shape extends DiagramElement {
   constructor(type: string, base?: Partial<Shape>) {
     super(type, base);
   }
+
+  // No reference fields to resolve/replace
+  resolveReferences(_elementReferenceMap: Map<string, OntoumlElement>): void {}
 }


### PR DESCRIPTION
## Updated required fields

### ClassView

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| modelElement | modelElement |
| shape | - |

### Class

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| propertyAssignments | - |
| stereotype | - |
| isAbstract | - |
| isDerived | - |
| properties | - |
| literals | - |
| restrictedTo | - |
| isExtensional | - |
| isPowertype | - |
| order | - |

### Reference

| From | To |
|:---|:--|
| type | type |
| id | id |

### Diagram

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| contents | - |
| owner | - |

### GeneralizationSetView

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| modelElement | modelElement |
| shape | - |

### GeneralizationSet

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| propertyAssignments | - |
| isDisjoint | - |
| isComplete | - |
| categorizer | - |
| generalizations | - |

### GeneralizationView

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| modelElement | modelElement |
| source | source |
| target | target |
| shape | - |

### Generalization

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| propertyAssignments | - |
| general | general |
| specific | specific |

### Literal

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| propertyAssignments | - |

### PackageView

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| modelElement | modelElement |
| shape | - |

### Package

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| propertyAssignments | - |
| contents | - |

### "Point"

| From | To |
|:---|:--|
| x | x |
| y | y |

### Path

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| points | - |

### Project

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| model | - |
| diagrams | - |

### Property

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| cardinality | - |
| stereotype | - |
| propertyAssignments | - |
| propertyType | - |
| subsettedProperties | - |
| redefinedProperties | - |
| aggregationKind | - |
| isDerived | - |
| isOrdered | - |
| isReadOnly | - |

### Rectangle

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| x | - |
| y | - |
| width | - |
| height | - |

### RelationView

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| modelElement | modelElement |
| source | source |
| target | target |
| shape | - |

### Relation

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| stereotype | - |
| propertyAssignments | - |
| isAbstract | - |
| isDerived | - |
| properties | - |

### Text

| From | To |
|:---|:--|
| type | type |
| id | id |
| name | - |
| description | - |
| x | - |
| y | - |
| width | - |
| height | - |
| value | - |

There is a couple of choices that feel a bit inconsistent for me:

- In `Relation`, the field properties can be (i) omitted, (ii) `null`, (iii) or an empty properties array.
- Other single references, like `general` and `specific` in `Generalization`, cannot be set to `null`.
